### PR TITLE
Set production mode in Webpack config to prevent warnings in console

### DIFF
--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -16,6 +16,7 @@ module.exports = [{
       path.join(__dirname, 'src/demo/index.jsx'),
     ],
   },
+  mode: 'production',
   module: {
     rules: [
       {
@@ -32,7 +33,7 @@ module.exports = [{
             options: {
               modules: {
                 localIdentName: '[name]__[local]__[hash:base64:5]',
-              }
+              },
             },
           },
           { loader: 'postcss-loader' },
@@ -49,7 +50,7 @@ module.exports = [{
         test: /\.(svg|jpg)$/,
         use: [
           { loader: 'file-loader?hash=sha512&digest=hex&name=[hash].[ext]' },
-        ]
+        ],
       },
     ],
   },

--- a/webpack.config.lib.js
+++ b/webpack.config.lib.js
@@ -8,6 +8,7 @@ module.exports = [{
       path.join(__dirname, 'src/lib/index.js'),
     ],
   },
+  mode: 'production',
   module: {
     rules: [
       {
@@ -41,7 +42,7 @@ module.exports = [{
         test: /\.(svg|jpg)$/,
         use: [
           { loader: 'file-loader?hash=sha512&digest=hex&name=[hash].[ext]' },
-        ]
+        ],
       },
     ],
   },


### PR DESCRIPTION
As recommended by Webpack warning in console, see #29.