### PR TITLE
Block merge of fixup commits (#75)

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,13 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-merge-with-autosquash-commits:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Block Merge with Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build and run tests
+name: Build and Run Tests
 
 on:
   - push


### PR DESCRIPTION
This is why:
![image](https://user-images.githubusercontent.com/5614085/82044618-f3157600-96ad-11ea-9a8a-5492e4b61b80.png)

Closes #75.