### PR TITLE
Fix helper texts in horizontal form fields

### DIFF
--- a/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
@@ -66,6 +66,7 @@ exports[`rendering renders correctly 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="resetEmailInput"
                   id="resetEmailInput__label"
@@ -214,6 +215,7 @@ exports[`rendering renders correctly 2`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="resetEmailInput"
@@ -391,6 +393,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="custom-id__resetEmailInput"

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
@@ -68,6 +68,7 @@ exports[`rendering renders correctly 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="usernameInput"
                   id="usernameInput__label"
@@ -130,6 +131,7 @@ exports[`rendering renders correctly 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="passwordInput"
@@ -309,6 +311,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="custom-id__usernameInput"
                   id="custom-id__usernameInput__label"
@@ -371,6 +374,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="custom-id__passwordInput"
@@ -539,6 +543,7 @@ exports[`rendering renders correctly with translations 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="usernameInput"
                   id="usernameInput__label"
@@ -601,6 +606,7 @@ exports[`rendering renders correctly with translations 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="passwordInput"
@@ -749,6 +755,7 @@ exports[`rendering renders correctly with username 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="usernameInput"
                   id="usernameInput__label"
@@ -811,6 +818,7 @@ exports[`rendering renders correctly with username 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="passwordInput"

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
@@ -66,6 +66,7 @@ exports[`rendering renders correctly 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="newPasswordInput"
                   id="newPasswordInput__label"
@@ -128,6 +129,7 @@ exports[`rendering renders correctly 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="newPasswordRepeatInput"
@@ -305,6 +307,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="custom-id__newPasswordInput"
                   id="custom-id__newPasswordInput__label"
@@ -367,6 +370,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="custom-id__newPasswordRepeatInput"
@@ -532,6 +536,7 @@ exports[`rendering renders correctly with translations 1`] = `
         isRootRequired
         rootSizeMedium
         
+        
         rootVariantOutline"
                   htmlFor="newPasswordInput"
                   id="newPasswordInput__label"
@@ -594,6 +599,7 @@ exports[`rendering renders correctly with translations 1`] = `
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
+        
         
         rootVariantOutline"
                   htmlFor="newPasswordRepeatInput"

--- a/src/lib/components/ui/MultipleSelectField/MultipleSelectField.scss
+++ b/src/lib/components/ui/MultipleSelectField/MultipleSelectField.scss
@@ -39,7 +39,7 @@
 
 // States
 .isRootRequired .label {
-  @include form-field-required-label();
+  @include form-field-label-required();
 }
 
 .isRootStateInvalid {

--- a/src/lib/components/ui/SelectField/SelectField.scss
+++ b/src/lib/components/ui/SelectField/SelectField.scss
@@ -49,7 +49,7 @@
 
 // States
 .isRootRequired .label {
-  @include form-field-required-label();
+  @include form-field-label-required();
 }
 
 .isRootStateInvalid {

--- a/src/lib/components/ui/TextArea/TextArea.scss
+++ b/src/lib/components/ui/TextArea/TextArea.scss
@@ -39,7 +39,7 @@
 
 // States
 .isRootRequired .label {
-  @include form-field-required-label();
+  @include form-field-label-required();
 }
 
 .isRootStateInvalid {

--- a/src/lib/components/ui/TextField/TextField.jsx
+++ b/src/lib/components/ui/TextField/TextField.jsx
@@ -5,11 +5,14 @@ import withForwardedRef from '../withForwardedRef';
 import styles from './TextField.scss';
 
 export const TextField = (props) => {
+  const SMALL_INPUT_SIZE = 10;
+
   let labelVisibilityClass = '';
   let rootFullWidthClass = '';
   let rootLayoutClass = '';
   let rootRequiredClass = '';
   let rootSizeClass = '';
+  let rootSmallInputClass = '';
   let rootValidationStateClass = '';
   let rootVariantClass = '';
 
@@ -19,6 +22,10 @@ export const TextField = (props) => {
 
   if (props.fullWidth) {
     rootFullWidthClass = styles.isRootFullWidth;
+  }
+
+  if (props.inputSize && props.inputSize <= SMALL_INPUT_SIZE) {
+    rootSmallInputClass = styles.hasRootSmallInput;
   }
 
   if (props.layout === 'horizontal') {
@@ -67,6 +74,7 @@ export const TextField = (props) => {
         ${rootLayoutClass}
         ${rootRequiredClass}
         ${rootSizeClass}
+        ${rootSmallInputClass}
         ${rootValidationStateClass}
         ${rootVariantClass}
       `).trim()}

--- a/src/lib/components/ui/TextField/TextField.scss
+++ b/src/lib/components/ui/TextField/TextField.scss
@@ -73,6 +73,10 @@
   @include form-field-vertical-neighbor();
 }
 
+.hasRootSmallInput {
+  @include form-field-layout-with-small-input();
+}
+
 // Sizes
 .rootSizeSmall {
   @include form-field-size(small);

--- a/src/lib/components/ui/TextField/TextField.scss
+++ b/src/lib/components/ui/TextField/TextField.scss
@@ -39,7 +39,7 @@
 
 // States
 .isRootRequired .label {
-  @include form-field-required-label();
+  @include form-field-label-required();
 }
 
 .isRootStateInvalid {

--- a/src/lib/components/ui/TextField/__tests__/__snapshots__/TextField.test.jsx.snap
+++ b/src/lib/components/ui/TextField/__tests__/__snapshots__/TextField.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`rendering renders correctly mandatory props only 1`] = `
         
         rootSizeMedium
         
+        
         rootVariantOutline"
   htmlFor="test"
   id="test__label"
@@ -42,6 +43,7 @@ exports[`rendering renders correctly with all props 1`] = `
         rootLayoutHorizontal
         isRootRequired
         rootSizeLarge
+        hasRootSmallInput
         isRootStateInvalid
         rootVariantFilled"
   htmlFor="test"
@@ -88,6 +90,7 @@ exports[`rendering renders correctly with hidden label 1`] = `
         rootLayoutVertical
         
         rootSizeMedium
+        
         
         rootVariantOutline"
   htmlFor="test"

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -7,6 +7,13 @@
 @import '../transitions';
 @import 'states';
 
+@mixin form-field-label-required() {
+  &::after {
+    content: $form-field-required-sign;
+    color: $form-field-required-sign-color;
+  }
+}
+
 @mixin form-field-input-container() {
   position: relative; // 1.
   display: inline-flex;
@@ -129,11 +136,4 @@
   font-size: $form-field-helper-text-font-size;
   line-height: $form-field-helper-text-line-height;
   color: $form-field-helper-text-color;
-}
-
-@mixin form-field-required-label() {
-  &::after {
-    content: $form-field-required-sign;
-    color: $form-field-required-sign-color;
-  }
 }

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -125,8 +125,6 @@
 }
 
 @mixin form-field-helper-text() {
-  width: $form-field-input-width;
-  min-width: $form-field-input-min-width;
   font-style: $form-field-helper-text-font-style;
   font-size: $form-field-helper-text-font-size;
   line-height: $form-field-helper-text-line-height;

--- a/src/lib/styles/tools/forms/_layouts.scss
+++ b/src/lib/styles/tools/forms/_layouts.scss
@@ -1,12 +1,23 @@
-// 1. Define grid spacing as padding on child elements because grid areas make row and column gaps
+// 1. Form fields in vertical layout take as much space as they need. Labels and helper texts do
+//    *not* wrap unless forced by container of the field.
+// 2. Form fields in horizontal layout only take as much space as their label needs without being
+//    wrapped (`max-content`). Helper text is aligned below input and wrapped.
+// 3. Define grid spacing as padding on child elements because grid areas make row and column gaps
 //    show up even when not necessary.
+// 4. When input size is small and form field layout is set to horizontal, expand helper text over
+//    full form field width to improve its readability. Otherwise the text would be packed into a
+//    very narrow column and hard to read. To prevent the helper text from growing the layout more
+//    than necessary (ie. in state without helper text) `min-content` grid sizing must be used along
+//    with disabled wrapping of label.
+// 5. Full-width horizontal form fields prefer not wrapping the label unless necessary
+//    (`max-content`).
 
 @import '../../settings/forms';
 @import '../../settings/forms-theme';
 @import '../breakpoints';
 
 @mixin form-field-layout-vertical() {
-  display: inline-block;
+  display: inline-block; // 1.
 
   .label {
     padding-bottom: $form-field-vertical-inner-gap;
@@ -21,8 +32,8 @@
   @include form-field-layout-vertical();
 
   @include breakpoint-up($form-field-horizontal-breakpoint) {
-    display: inline-grid;
-    grid-template-columns: max-content min-content;
+    display: inline-grid; // 2.
+    grid-template-columns: max-content min-content; // 2.
     grid-template-areas:
       "label input"
       ". helpertext";
@@ -31,8 +42,8 @@
     .label {
       grid-area: label;
       min-width: $form-field-horizontal-label-min-width;
-      padding-right: $form-field-horizontal-inner-gap; // 1.
-      padding-bottom: 0; // 1.
+      padding-right: $form-field-horizontal-inner-gap; // 3.
+      padding-bottom: 0; // 3.
       text-align: $form-field-horizontal-label-alignment;
     }
 
@@ -42,6 +53,21 @@
 
     .helperText {
       grid-area: helpertext;
+    }
+  }
+}
+
+@mixin form-field-layout-with-small-input() {
+  @include breakpoint-up($form-field-horizontal-breakpoint) {
+    &.rootLayoutHorizontal {
+      grid-template-columns: min-content min-content; // 4.
+      grid-template-areas:
+        "label input"
+        "helpertext helpertext"; // 4.
+    }
+
+    &.rootLayoutHorizontal .label {
+      white-space: nowrap; // 4.
     }
   }
 }
@@ -58,7 +84,7 @@
   @include breakpoint-up($form-field-horizontal-breakpoint) {
     &.rootLayoutHorizontal {
       display: grid;
-      grid-template-columns: max-content 1fr;
+      grid-template-columns: max-content 1fr; // 5.
     }
   }
 }

--- a/src/lib/styles/tools/forms/_layouts.scss
+++ b/src/lib/styles/tools/forms/_layouts.scss
@@ -1,13 +1,12 @@
-// 1. Redefine due to specificity.
+// 1. Define grid spacing as padding on child elements because grid areas make row and column gaps
+//    show up even when not necessary.
 
 @import '../../settings/forms';
 @import '../../settings/forms-theme';
 @import '../breakpoints';
 
 @mixin form-field-layout-vertical() {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
+  display: inline-block;
 
   .label {
     padding-bottom: $form-field-vertical-inner-gap;
@@ -23,24 +22,22 @@
 
   @include breakpoint-up($form-field-horizontal-breakpoint) {
     display: inline-grid;
-    grid-template-columns: auto 1fr;
-    grid-template-rows: auto auto;
+    grid-template-columns: max-content min-content;
     grid-template-areas:
       "label input"
       ". helpertext";
+    align-items: center;
 
     .label {
       grid-area: label;
-      align-self: center;
       min-width: $form-field-horizontal-label-min-width;
-      padding-right: $form-field-horizontal-inner-gap;
-      padding-bottom: 0;
+      padding-right: $form-field-horizontal-inner-gap; // 1.
+      padding-bottom: 0; // 1.
       text-align: $form-field-horizontal-label-alignment;
     }
 
     .inputContainer {
       grid-area: input;
-      justify-self: start;
     }
 
     .helperText {
@@ -51,27 +48,17 @@
 
 @mixin form-field-full-width() {
   display: flex;
-  align-items: stretch;
+  flex-direction: column;
   width: 100%;
-
-  .inputContainer {
-    flex-grow: 1;
-  }
 
   .input {
     width: 100%;
   }
 
-  .helperText {
-    width: 100%;
-    max-width: none;
-  }
-
-  &.rootLayoutHorizontal {
-    display: grid; // 1.
-  }
-
-  &.rootLayoutHorizontal .inputContainer {
-    justify-self: stretch;
+  @include breakpoint-up($form-field-horizontal-breakpoint) {
+    &.rootLayoutHorizontal {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+    }
   }
 }

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -461,7 +461,7 @@
   // 2. Append non-breaking space and asterisk to required filed labels.
 
   // Forms fields: common properties
-  --rui-form-field-input-width: 100%; // 1.
+  --rui-form-field-input-width: auto; // 1.
   --rui-form-field-input-min-width: 240px; // 1.
   --rui-form-field-disabled-select-option-color: var(--rui-color-gray-300);
   --rui-form-field-label-font-size: var(--rui-typography-size-0);


### PR DESCRIPTION
- Prevent form field helper text from taking up more space than necessary when input size is smaller than default
- Wrap validation message in horizontal form field layout to prevent unwanted shift of adjacent elements when the message shows up
- Improve readability of helper text in horizontal `Text Field` when input size is too small

Closes #46.

**Before:**

![image](https://user-images.githubusercontent.com/5614085/83330817-0cafe380-a292-11ea-92dd-687db27cff08.png)

![image](https://user-images.githubusercontent.com/5614085/83330785-eab66100-a291-11ea-9430-221595f087ae.png)

**After:**

![image](https://user-images.githubusercontent.com/5614085/83330825-1b969600-a292-11ea-90af-cb6804967908.png)

![image](https://user-images.githubusercontent.com/5614085/83330804-fc980400-a291-11ea-9b94-b1c659c056bb.png)
