### PR TITLE
Create `FormLayout` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8953,9 +8953,9 @@
       }
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
@@ -14464,8 +14464,15 @@
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
-      "dev": true
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+    },
+    "react-keyed-flatten-children": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-1.2.0.tgz",
+      "integrity": "sha512-gJoD3br3tK59+AOKlzb+7G39YtkSC4gWjQjDbWOmHjW7pxgYomnRBemKXuNBafnPYSKpjp7evOlxtGEHwiP11g==",
+      "requires": {
+        "react-is": "^16.8.6"
+      }
     },
     "react-test-renderer": {
       "version": "16.13.0",
@@ -15382,8 +15389,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "schema-utils": {
@@ -18838,8 +18844,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "os-locale": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "normalize.css": "^8.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-keyed-flatten-children": "^1.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/demo/pages/DemoContainer.jsx
+++ b/src/demo/pages/DemoContainer.jsx
@@ -21,6 +21,7 @@ import {
   CTAStart,
   CheckboxField,
   ForgotPassword,
+  FormLayout,
   LayoutCenter,
   List,
   ListItem,
@@ -342,6 +343,371 @@ class DemoContainer extends React.Component {
                     <Placeholder text="secondary end" />
                   </CTAEnd>
                 </CTA>
+              )}
+            />
+            <h3 id="layout-components-form-layout" className="typography-size-4 mb-6">Form Layout</h3>
+            <p>
+              Vertical Form Layout works similar to List except that List Items are not needed.
+              Vertical form field layout is forced.
+            </p>
+            <Documentation
+              name="Vertical Form Layout"
+              component={(
+                <FormLayout>
+                  <>
+                    <TextField
+                      id="formLayoutVerticalFirstName"
+                      changeHandler={logger}
+                      label="First Name"
+                    />
+                    <TextField
+                      id="formLayoutVerticalLastName"
+                      changeHandler={logger}
+                      label="Last Name"
+                    />
+                  </>
+                  <TextField
+                    id="formLayoutVerticalEmail"
+                    changeHandler={logger}
+                    label="Email address"
+                    type="email"
+                    helperText="Optional"
+                  />
+                  <>
+                    <TextField
+                      id="formLayoutVerticalAddress1"
+                      changeHandler={logger}
+                      label="Address"
+                      placeholder="Address line 1"
+                    />
+                    <TextField
+                      id="formLayoutVerticalAddress2"
+                      changeHandler={logger}
+                      isLabelVisible={false}
+                      label="Address 2"
+                      placeholder="Address line 2"
+                    />
+                    <TextField
+                      id="formLayoutVerticalZip"
+                      changeHandler={logger}
+                      helperText="ZIP should be 5 to 6 digits long code."
+                      label="ZIP"
+                      inputSize={6}
+                      validationState="invalid"
+                    />
+                    <TextField
+                      id="formLayoutVerticalCountry"
+                      changeHandler={logger}
+                      label="Country"
+                    />
+                    <CheckboxField
+                      id="formLayoutVerticalDelivery"
+                      changeHandler={logger}
+                      label="This is my delivery address"
+                    />
+                  </>
+                  <SelectField
+                    id="formLayoutVerticalFruit"
+                    changeHandler={logger}
+                    label="Your favourite fruit"
+                    options={this.exampleOptions}
+                  />
+                  <TextArea
+                    id="formLayoutVerticalMessage"
+                    changeHandler={logger}
+                    fullWidth
+                    label="Message"
+                    rows={3}
+                  />
+                  <Toggle
+                    id="formLayoutVerticalNewsletter"
+                    changeHandler={logger}
+                    checked
+                    description="Only once per week!"
+                    label="Receive weekly newsletter"
+                    required
+                  />
+                  <Radio
+                    id="formLayoutVerticalFruit2"
+                    changeHandler={logger}
+                    label="And fruit again!"
+                    options={this.exampleOptions}
+                    value="apples"
+                  />
+                </FormLayout>
+              )}
+            />
+            <p>
+              Horizontal Form Layout is designed for horizontal form fields.
+              It is applied starting from <code>md</code> viewport size onwards.
+              Horizontal form field layout is forced.
+            </p>
+            <Documentation
+              name="Horizontal Form Layout"
+              component={(
+                <FormLayout fieldLayout="horizontal">
+                  <>
+                    <TextField
+                      id="formLayoutHorizontalFirstName"
+                      changeHandler={logger}
+                      label="First Name"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalLastName"
+                      changeHandler={logger}
+                      label="Last Name"
+                    />
+                  </>
+                  <TextField
+                    id="formLayoutHorizontalEmail"
+                    changeHandler={logger}
+                    label="Email address"
+                    type="email"
+                    helperText="Optional"
+                  />
+                  <>
+                    <TextField
+                      id="formLayoutHorizontalAddress1"
+                      changeHandler={logger}
+                      label="Address"
+                      placeholder="Address line 1"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalAddress2"
+                      changeHandler={logger}
+                      isLabelVisible={false}
+                      label="Address 2"
+                      placeholder="Address line 2"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalZip"
+                      changeHandler={logger}
+                      helperText="ZIP should be 5 to 6 digits long code."
+                      label="ZIP"
+                      inputSize={6}
+                      validationState="invalid"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalCountry"
+                      changeHandler={logger}
+                      label="Country"
+                    />
+                    <CheckboxField
+                      id="formLayoutHorizontalDelivery"
+                      changeHandler={logger}
+                      label="This is my delivery address"
+                    />
+                  </>
+                  <SelectField
+                    id="formLayoutHorizontalFruit"
+                    changeHandler={logger}
+                    label="Your favourite fruit"
+                    options={this.exampleOptions}
+                  />
+                  <TextArea
+                    id="formLayoutHorizontalMessage"
+                    changeHandler={logger}
+                    fullWidth
+                    label="Message"
+                    rows={3}
+                  />
+                  <Toggle
+                    id="formLayoutHorizontalNewsletter"
+                    changeHandler={logger}
+                    checked
+                    label="Receive weekly newsletter"
+                    required
+                    description="Only once per week!"
+                  />
+                  <Radio
+                    id="formLayoutHorizontalFruit2"
+                    changeHandler={logger}
+                    label="And fruit again!"
+                    options={this.exampleOptions}
+                    value="apples"
+                  />
+                </FormLayout>
+              )}
+            />
+            <Documentation
+              name="Horizontal Form Layout with Custom Label Width"
+              component={(
+                <FormLayout
+                  fieldLayout="horizontal"
+                  labelWidth="15em"
+                >
+                  <>
+                    <TextField
+                      id="formLayoutHorizontalCustomFirstName"
+                      changeHandler={logger}
+                      label="First Name"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalCustomLastName"
+                      changeHandler={logger}
+                      label="Last Name"
+                    />
+                  </>
+                  <TextField
+                    id="formLayoutHorizontalCustomEmail"
+                    changeHandler={logger}
+                    label="Email address"
+                    type="email"
+                    helperText="Optional"
+                  />
+                  <>
+                    <TextField
+                      id="formLayoutHorizontalCustomAddress1"
+                      changeHandler={logger}
+                      label="Address"
+                      placeholder="Address line 1"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalCustomAddress2"
+                      changeHandler={logger}
+                      isLabelVisible={false}
+                      label="Address 2"
+                      placeholder="Address line 2"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalCustomZip"
+                      changeHandler={logger}
+                      helperText="ZIP should be 5 to 6 digits long code."
+                      label="ZIP"
+                      inputSize={6}
+                      validationState="invalid"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalCustomCountry"
+                      changeHandler={logger}
+                      label="Country"
+                    />
+                    <CheckboxField
+                      id="formLayoutHorizontalCustomDelivery"
+                      changeHandler={logger}
+                      label="This is my delivery address"
+                    />
+                  </>
+                  <SelectField
+                    id="formLayoutHorizontalCustomFruit"
+                    changeHandler={logger}
+                    label="Your favourite fruit"
+                    options={this.exampleOptions}
+                  />
+                  <TextArea
+                    id="formLayoutHorizontalCustomMessage"
+                    changeHandler={logger}
+                    fullWidth
+                    label="Message"
+                    rows={3}
+                  />
+                  <Toggle
+                    id="formLayoutHorizontalCustomNewsletter"
+                    changeHandler={logger}
+                    checked
+                    label="Receive weekly newsletter"
+                    required
+                    description="Only once per week!"
+                  />
+                  <Radio
+                    id="formLayoutHorizontalCustomFruit2"
+                    changeHandler={logger}
+                    label="And fruit again!"
+                    options={this.exampleOptions}
+                    value="apples"
+                  />
+                </FormLayout>
+              )}
+            />
+            <Documentation
+              name="Horizontal Form Layout with Auto-Width Labels (Firefox only, custom fallback)"
+              component={(
+                <FormLayout
+                  fieldLayout="horizontal"
+                  labelWidth="auto"
+                  labelAutoWidthFallback="12em"
+                >
+                  <>
+                    <TextField
+                      id="formLayoutHorizontalAutoFirstName"
+                      changeHandler={logger}
+                      label="First Name"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalAutoLastName"
+                      changeHandler={logger}
+                      label="Last Name"
+                    />
+                  </>
+                  <TextField
+                    id="formLayoutHorizontalAutoEmail"
+                    changeHandler={logger}
+                    label="Email address"
+                    type="email"
+                    helperText="Optional"
+                  />
+                  <>
+                    <TextField
+                      id="formLayoutHorizontalAutoAddress1"
+                      changeHandler={logger}
+                      label="Address"
+                      placeholder="Address line 1"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalAutoAddress2"
+                      changeHandler={logger}
+                      isLabelVisible={false}
+                      label="Address 2"
+                      placeholder="Address line 2"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalAutoZip"
+                      changeHandler={logger}
+                      helperText="ZIP should be 5 to 6 digits long code."
+                      label="ZIP"
+                      inputSize={6}
+                      validationState="invalid"
+                    />
+                    <TextField
+                      id="formLayoutHorizontalAutoCountry"
+                      changeHandler={logger}
+                      label="Country"
+                    />
+                    <CheckboxField
+                      id="formLayoutHorizontalAutoDelivery"
+                      changeHandler={logger}
+                      label="This is my delivery address"
+                    />
+                  </>
+                  <SelectField
+                    id="formLayoutHorizontalAutoFruit"
+                    changeHandler={logger}
+                    label="Your favourite fruit"
+                    options={this.exampleOptions}
+                  />
+                  <TextArea
+                    id="formLayoutHorizontalAutoMessage"
+                    changeHandler={logger}
+                    fullWidth
+                    label="Message"
+                    rows={3}
+                  />
+                  <Toggle
+                    id="formLayoutHorizontalAutoNewsletter"
+                    changeHandler={logger}
+                    checked
+                    label="Receive weekly newsletter"
+                    required
+                    description="Only once per week!"
+                  />
+                  <Radio
+                    id="formLayoutHorizontalAutoFruit2"
+                    changeHandler={logger}
+                    label="And fruit again!"
+                    options={this.exampleOptions}
+                    value="apples"
+                  />
+                </FormLayout>
               )}
             />
             <h3 id="layout-components-list" className="typography-size-4 mb-6">List</h3>

--- a/src/demo/pages/navigation.js
+++ b/src/demo/pages/navigation.js
@@ -36,6 +36,10 @@ export default [
         title: 'CTA',
       },
       {
+        link: '#layout-components-form-layout',
+        title: 'Form Layout',
+      },
+      {
         link: '#layout-components-list',
         title: 'List',
       },

--- a/src/lib/components/layout/CardList/CardList.jsx
+++ b/src/lib/components/layout/CardList/CardList.jsx
@@ -1,3 +1,4 @@
+import flattenChildren from 'react-keyed-flatten-children';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './CardList.scss';
@@ -19,7 +20,7 @@ const CardList = (props) => {
       className={styles.root}
       {...other}
     >
-      {React.Children.map(children, (child) => {
+      {flattenChildren(children).map((child) => {
         if (!React.isValidElement(child)) {
           return null;
         }

--- a/src/lib/components/layout/CardList/CardList.scss
+++ b/src/lib/components/layout/CardList/CardList.scss
@@ -1,3 +1,4 @@
+@import '../../../styles/settings/layouts';
 @import '../../../styles/tools/breakpoints';
 @import '../../../styles/tools/offset';
 @import './theme';
@@ -8,7 +9,7 @@
   grid-template-columns: 1fr;
   grid-template-rows: auto;
   grid-gap: $card-list-grid-gap;
-  margin-bottom: offset(4);
+  margin-bottom: $layout-common-bottom-offset;
 
   @include breakpoint-up(sm) {
     grid-template-columns: repeat(auto-fit, minmax($card-list-card-min-width, $card-list-card-max-width));

--- a/src/lib/components/layout/FormLayout/FormLayout.jsx
+++ b/src/lib/components/layout/FormLayout/FormLayout.jsx
@@ -1,0 +1,102 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './FormLayout.scss';
+
+const FormLayout = (props) => {
+  const {
+    children,
+    fieldLayout,
+    id,
+    labelAutoWidthFallback,
+    labelWidth,
+  } = props;
+
+  if (!children) {
+    return null;
+  }
+
+  let customLabelWidth;
+
+  if (labelWidth !== 'auto' && labelWidth !== 'default') {
+    customLabelWidth = labelWidth;
+  }
+
+  const fieldLayoutClass = (layout) => {
+    if (layout === 'horizontal') {
+      return styles.rootFieldLayoutHorizontal;
+    }
+
+    return styles.rootFieldLayoutVertical;
+  };
+
+  const labelWidthClass = (width) => {
+    if (width !== 'auto' && width !== 'default') {
+      return styles.hasRootLabelWidthCustom;
+    }
+
+    if (width === 'auto') {
+      return styles.hasRootLabelWidthAuto;
+    }
+
+    return styles.hasRootLabelWidthDefault;
+  };
+
+  const inlineStyle = (customWidth, customAutoWidthFallback) => {
+    const style = {};
+
+    if (customWidth) {
+      style['--rui-custom-label-width'] = customWidth;
+    }
+
+    if (customAutoWidthFallback) {
+      style['--rui-custom-label-auto-width-fallback'] = customAutoWidthFallback;
+    }
+
+    return style;
+  };
+
+  return (
+    <div
+      id={id}
+      className={[
+        styles.root,
+        fieldLayoutClass(fieldLayout),
+        fieldLayout === 'horizontal' ? labelWidthClass(labelWidth) : '',
+        labelAutoWidthFallback ? styles.hasRootCustomLabelAutoWidthFallback : '',
+      ].join(' ')}
+      style={inlineStyle(customLabelWidth, labelAutoWidthFallback)}
+    >
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) {
+          return null;
+        }
+
+        return React.cloneElement(child, {
+          inFormLayout: true,
+          layout: fieldLayout,
+        });
+      })}
+    </div>
+  );
+};
+
+FormLayout.defaultProps = {
+  children: null,
+  fieldLayout: 'vertical',
+  id: undefined,
+  labelAutoWidthFallback: undefined,
+  labelWidth: 'default',
+};
+
+FormLayout.propTypes = {
+  children: PropTypes.node,
+  fieldLayout: PropTypes.oneOf(['horizontal', 'vertical']),
+  id: PropTypes.string,
+  labelAutoWidthFallback: PropTypes.string,
+  labelWidth: PropTypes.oneOfType([
+    PropTypes.oneOf(['auto', 'default']),
+    PropTypes.string,
+  ]),
+};
+
+export default FormLayout;

--- a/src/lib/components/layout/FormLayout/FormLayout.jsx
+++ b/src/lib/components/layout/FormLayout/FormLayout.jsx
@@ -1,3 +1,4 @@
+import flattenChildren from 'react-keyed-flatten-children';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './FormLayout.scss';
@@ -66,7 +67,7 @@ const FormLayout = (props) => {
       ].join(' ')}
       style={inlineStyle(customLabelWidth, labelAutoWidthFallback)}
     >
-      {React.Children.map(children, (child) => {
+      {flattenChildren(children).map((child) => {
         if (!React.isValidElement(child)) {
           return null;
         }

--- a/src/lib/components/layout/FormLayout/FormLayout.scss
+++ b/src/lib/components/layout/FormLayout/FormLayout.scss
@@ -1,0 +1,55 @@
+// 1. Form field label width is defined using custom property. Form Layout variants are created just
+//    by adjusting this value, either through a particular modification class, or manually through
+//    a prop. Form fields then inherit the layout using the `subgrid` feature which makes it possible
+//    to turn on automatic size of grid column with labels (in supporting browsers). There is always
+//    a fallback value for browsers that don't support `subgrid` (see `tools/forms/_layouts.scss`).
+//    This value is passed down to form fields utilising custom property cascade.
+// 2. By default, form field label width is set to a configurable global value.
+// 3. Custom label width can be entered individually through a prop for each use of Form Layout.
+// 4. Form Layout can also automatically adjust the width of column with labels according to the
+//    longest label (which is possible only with `subgrid`). By default, automatic width is limited
+//    to 50 % of available horizontal space. However, the automatic width is currently supported
+//    only in Firefox so a fallback value is necessary (a global default which can be customised per
+//    use).
+
+@import '../../../styles/settings/forms';
+@import '../../../styles/settings/forms-theme';
+@import '../../../styles/settings/layouts';
+@import '../../../styles/tools/breakpoints';
+@import '../../../styles/tools/offset';
+
+.root {
+  margin-bottom: $layout-common-bottom-offset;
+}
+
+.rootFieldLayoutVertical,
+.rootFieldLayoutHorizontal {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-row-gap: $form-field-vertical-outer-spacing;
+}
+
+.rootFieldLayoutHorizontal {
+  @include breakpoint-up($form-field-horizontal-breakpoint) {
+    grid-template-columns: var(--rui-local-label-width) 1fr; // 1.
+  }
+}
+
+.hasRootLabelWidthDefault {
+  --rui-local-label-width: #{$form-layout-horizontal-label-default-width}; // 1., 2.
+  --rui-local-label-width-fallback: #{$form-layout-horizontal-label-default-width}; // 1., 2.
+}
+
+.hasRootLabelWidthCustom {
+  --rui-local-label-width: var(--rui-custom-label-width); // 3.
+  --rui-local-label-width-fallback: var(--rui-custom-label-width); // 3.
+}
+
+.hasRootLabelWidthAuto {
+  --rui-local-label-width: #{$form-layout-horizontal-label-auto-width}; // 4.
+  --rui-local-label-width-fallback: #{$form-layout-horizontal-label-auto-width-fallback}; // 4.
+}
+
+.hasRootLabelWidthAuto.hasRootCustomLabelAutoWidthFallback {
+  --rui-local-label-width-fallback: var(--rui-custom-label-auto-width-fallback); // 4.
+}

--- a/src/lib/components/layout/FormLayout/__tests__/FormLayout.test.jsx
+++ b/src/lib/components/layout/FormLayout/__tests__/FormLayout.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import FormLayout from '../FormLayout';
+
+describe('rendering', () => {
+  it('renders correctly with a single child', () => {
+    const tree = shallow((
+      <FormLayout>
+        <span>content</span>
+      </FormLayout>
+    ));
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with multiple children', () => {
+    const tree = shallow((
+      <FormLayout>
+        <span>content 1</span>
+        <span>content 2</span>
+        <span>content 3</span>
+      </FormLayout>
+    ));
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with custom label width', () => {
+    const tree = shallow((
+      <FormLayout
+        fieldLayout="horizontal"
+        id="test-id"
+        labelWidth="300px"
+      >
+        <span>content</span>
+      </FormLayout>
+    ));
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with all props', () => {
+    const tree = shallow((
+      <FormLayout
+        fieldLayout="horizontal"
+        id="test-id"
+        labelAutoWidthFallback="200px"
+        labelWidth="auto"
+      >
+        <span>content</span>
+      </FormLayout>
+    ));
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/layout/FormLayout/__tests__/__snapshots__/FormLayout.test.jsx.snap
+++ b/src/lib/components/layout/FormLayout/__tests__/__snapshots__/FormLayout.test.jsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering renders correctly with a single child 1`] = `
+<div
+  className="root rootFieldLayoutVertical  "
+  style={Object {}}
+>
+  <span
+    inFormLayout={true}
+    key=".0"
+    layout="vertical"
+  >
+    content
+  </span>
+</div>
+`;
+
+exports[`rendering renders correctly with all props 1`] = `
+<div
+  className="root rootFieldLayoutHorizontal hasRootLabelWidthAuto hasRootCustomLabelAutoWidthFallback"
+  id="test-id"
+  style={
+    Object {
+      "--rui-custom-label-auto-width-fallback": "200px",
+    }
+  }
+>
+  <span
+    inFormLayout={true}
+    key=".0"
+    layout="horizontal"
+  >
+    content
+  </span>
+</div>
+`;
+
+exports[`rendering renders correctly with custom label width 1`] = `
+<div
+  className="root rootFieldLayoutHorizontal hasRootLabelWidthCustom "
+  id="test-id"
+  style={
+    Object {
+      "--rui-custom-label-width": "300px",
+    }
+  }
+>
+  <span
+    inFormLayout={true}
+    key=".0"
+    layout="horizontal"
+  >
+    content
+  </span>
+</div>
+`;
+
+exports[`rendering renders correctly with multiple children 1`] = `
+<div
+  className="root rootFieldLayoutVertical  "
+  style={Object {}}
+>
+  <span
+    inFormLayout={true}
+    key=".0"
+    layout="vertical"
+  >
+    content 1
+  </span>
+  <span
+    inFormLayout={true}
+    key=".1"
+    layout="vertical"
+  >
+    content 2
+  </span>
+  <span
+    inFormLayout={true}
+    key=".2"
+    layout="vertical"
+  >
+    content 3
+  </span>
+</div>
+`;

--- a/src/lib/components/layout/FormLayout/index.js
+++ b/src/lib/components/layout/FormLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormLayout';

--- a/src/lib/components/layout/List/List.scss
+++ b/src/lib/components/layout/List/List.scss
@@ -1,7 +1,8 @@
+@import '../../../styles/settings/layouts';
 @import '../../../styles/tools/offset';
 
 .root {
-  margin-bottom: offset(4);
+  margin-bottom: $layout-common-bottom-offset;
 }
 
 .list {

--- a/src/lib/components/layout/Media/Media.scss
+++ b/src/lib/components/layout/Media/Media.scss
@@ -1,9 +1,10 @@
+@import '../../../styles/settings/layouts';
 @import '../../../styles/tools/offset';
 
 .media {
   display: flex;
   align-items: flex-start;
-  margin-bottom: offset(3);
+  margin-bottom: $layout-common-bottom-offset;
 }
 
 .object {

--- a/src/lib/components/layout/Row/Row.scss
+++ b/src/lib/components/layout/Row/Row.scss
@@ -1,10 +1,11 @@
+@import '../../../styles/settings/layouts';
 @import '../../../styles/tools/offset';
 
 .row {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  margin-bottom: offset(3);
+  margin-bottom: $layout-common-bottom-offset;
 }
 
 .start,

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
@@ -48,6 +48,7 @@ exports[`rendering renders correctly 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="resetEmailInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="E-mail"
@@ -62,6 +63,7 @@ exports[`rendering renders correctly 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -198,6 +200,7 @@ exports[`rendering renders correctly 2`] = `
                 fullWidth={true}
                 helperText={null}
                 id="resetEmailInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="E-mail"
@@ -212,6 +215,7 @@ exports[`rendering renders correctly 2`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -376,6 +380,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="custom-id__resetEmailInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="E-mail"
@@ -390,6 +395,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
@@ -50,6 +50,7 @@ exports[`rendering renders correctly 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="usernameInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="E-mail"
@@ -64,6 +65,7 @@ exports[`rendering renders correctly 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -114,6 +116,7 @@ exports[`rendering renders correctly 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="passwordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Password"
@@ -128,6 +131,7 @@ exports[`rendering renders correctly 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -293,6 +297,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="custom-id__usernameInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="E-mail"
@@ -307,6 +312,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -357,6 +363,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="custom-id__passwordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Password"
@@ -371,6 +378,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -525,6 +533,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="usernameInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="E-mail"
@@ -539,6 +548,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -589,6 +599,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="passwordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Heslo"
@@ -603,6 +614,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -737,6 +749,7 @@ exports[`rendering renders correctly with username 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="usernameInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Username"
@@ -751,6 +764,7 @@ exports[`rendering renders correctly with username 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -801,6 +815,7 @@ exports[`rendering renders correctly with username 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="passwordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Password"
@@ -815,6 +830,7 @@ exports[`rendering renders correctly with username 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
@@ -48,6 +48,7 @@ exports[`rendering renders correctly 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="newPasswordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="New password"
@@ -62,6 +63,7 @@ exports[`rendering renders correctly 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -112,6 +114,7 @@ exports[`rendering renders correctly 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="newPasswordRepeatInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Repeat new password"
@@ -126,6 +129,7 @@ exports[`rendering renders correctly 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -289,6 +293,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="custom-id__newPasswordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="New password"
@@ -303,6 +308,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -353,6 +359,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="custom-id__newPasswordRepeatInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Repeat new password"
@@ -367,6 +374,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -518,6 +526,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="newPasswordInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Nové heslo"
@@ -532,6 +541,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium
@@ -582,6 +592,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 fullWidth={true}
                 helperText={null}
                 id="newPasswordRepeatInput"
+                inFormLayout={false}
                 inputSize={null}
                 isLabelVisible={true}
                 label="Nové heslo znovu"
@@ -596,6 +607,7 @@ exports[`rendering renders correctly with translations 1`] = `
                 <label
                   className="root
         isRootFullWidth
+        
         rootLayoutVertical
         isRootRequired
         rootSizeMedium

--- a/src/lib/components/ui/CheckboxField/CheckboxField.jsx
+++ b/src/lib/components/ui/CheckboxField/CheckboxField.jsx
@@ -7,6 +7,8 @@ import styles from './CheckboxField.scss';
 export const CheckboxField = (props) => {
   let labelVisibilityClass = '';
   let labelPositionClass = '';
+  let rootInFormLayoutClass = '';
+  let rootLayoutClass = '';
   let rootValidationStateClass = '';
 
   if (!props.isLabelVisible) {
@@ -19,6 +21,14 @@ export const CheckboxField = (props) => {
     labelPositionClass = styles.labelPositionAfter;
   }
 
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
+  }
+
+  if (props.layout === 'horizontal') {
+    rootLayoutClass = styles.isRootLayoutHorizontal;
+  }
+
   if (props.validationState === 'invalid') {
     rootValidationStateClass = styles.isRootStateInvalid;
   } else if (props.validationState === 'valid') {
@@ -29,14 +39,16 @@ export const CheckboxField = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'checked', 'description', 'disabled', 'error', 'id', 'isLabelVisible',
-      'label', 'labelPosition', 'required', 'validationState', 'value'],
+    ['changeHandler', 'checked', 'description', 'disabled', 'error', 'id', 'inFormLayout', 'isLabelVisible',
+      'label', 'labelPosition', 'layout', 'required', 'validationState', 'value'],
   );
 
   return (
     <div
       className={`
         ${styles.root}
+        ${rootInFormLayoutClass}
+        ${rootLayoutClass}
         ${rootValidationStateClass}
       `.trim()}
     >
@@ -99,8 +111,10 @@ CheckboxField.defaultProps = {
   disabled: false,
   error: null,
   forwardedRef: undefined,
+  inFormLayout: false,
   isLabelVisible: true,
   labelPosition: 'after',
+  layout: 'vertical',
   required: false,
   validationState: null,
   value: undefined,
@@ -114,9 +128,11 @@ CheckboxField.propTypes = {
   error: PropTypes.string,
   forwardedRef: PropTypes.func,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,
   labelPosition: PropTypes.oneOf(['before', 'after']),
+  layout: PropTypes.oneOf(['horizontal', 'vertical']),
   required: PropTypes.bool,
   validationState: PropTypes.oneOf(['invalid', 'valid', 'warning']),
   value: PropTypes.oneOfType([

--- a/src/lib/components/ui/CheckboxField/CheckboxField.scss
+++ b/src/lib/components/ui/CheckboxField/CheckboxField.scss
@@ -21,6 +21,7 @@
 }
 
 .label {
+  @include form-field-label();
   @include form-checkbox-radio-label-styles($checkbox-radio-label-height, $checkbox-radio-padding-left);
 }
 
@@ -190,4 +191,12 @@
 
 .isRootStateWarning .input:checked + .label::before {
   background-color: $form-warning-color;
+}
+
+.isRootLayoutHorizontal {
+  position: relative; // Just set something until the component is refactored (#20).
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }

--- a/src/lib/components/ui/CheckboxField/tests/CheckboxField.test.jsx
+++ b/src/lib/components/ui/CheckboxField/tests/CheckboxField.test.jsx
@@ -19,6 +19,8 @@ describe('rendering', () => {
       label="label"
       disabled
       id="test"
+      inFormLayout
+      layout="horizontal"
       value="value"
       description="some help"
       error="some error"

--- a/src/lib/components/ui/CheckboxField/tests/__snapshots__/CheckboxField.test.jsx.snap
+++ b/src/lib/components/ui/CheckboxField/tests/__snapshots__/CheckboxField.test.jsx.snap
@@ -36,6 +36,8 @@ exports[`rendering renders correctly mandatory props only 1`] = `
 exports[`rendering renders correctly with all props 1`] = `
 <div
   className="root
+        isRootInFormLayout
+        isRootLayoutHorizontal
         isRootStateWarning"
 >
   <label

--- a/src/lib/components/ui/MultipleSelectField/MultipleSelectField.jsx
+++ b/src/lib/components/ui/MultipleSelectField/MultipleSelectField.jsx
@@ -7,6 +7,7 @@ import styles from './MultipleSelectField.scss';
 export const MultipleSelectField = (props) => {
   let labelVisibilityClass = '';
   let rootFullWidthClass = '';
+  let rootInFormLayoutClass = '';
   let rootLayoutClass = '';
   let rootRequiredClass = '';
   let rootSizeClass = '';
@@ -19,6 +20,10 @@ export const MultipleSelectField = (props) => {
 
   if (props.fullWidth) {
     rootFullWidthClass = styles.isRootFullWidth;
+  }
+
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
   }
 
   if (props.layout === 'horizontal') {
@@ -55,7 +60,7 @@ export const MultipleSelectField = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'isLabelVisible',
+    ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'inFormLayout', 'isLabelVisible',
       'label', 'layout', 'options', 'required', 'size', 'validationState', 'value', 'variant'],
   );
 
@@ -64,6 +69,7 @@ export const MultipleSelectField = (props) => {
       className={(`
         ${styles.root}
         ${rootFullWidthClass}
+        ${rootInFormLayoutClass}
         ${rootLayoutClass}
         ${rootRequiredClass}
         ${rootSizeClass}
@@ -129,6 +135,7 @@ MultipleSelectField.defaultProps = {
   forwardedRef: undefined,
   fullWidth: false,
   helperText: null,
+  inFormLayout: false,
   isLabelVisible: true,
   layout: 'vertical',
   required: false,
@@ -145,6 +152,7 @@ MultipleSelectField.propTypes = {
   fullWidth: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,
   layout: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/src/lib/components/ui/MultipleSelectField/MultipleSelectField.scss
+++ b/src/lib/components/ui/MultipleSelectField/MultipleSelectField.scss
@@ -11,6 +11,10 @@
   @include form-field-horizontal-neighbor();
 }
 
+.label {
+  @include form-field-label();
+}
+
 .inputContainer {
   @include form-field-input-container();
 }
@@ -71,6 +75,10 @@
 .isRootFullWidth {
   @include form-field-full-width();
   @include form-field-vertical-neighbor();
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }
 
 // Sizes

--- a/src/lib/components/ui/MultipleSelectField/tests/MultipleSelectField.test.jsx
+++ b/src/lib/components/ui/MultipleSelectField/tests/MultipleSelectField.test.jsx
@@ -45,6 +45,7 @@ describe('rendering', () => {
   it('renders correctly with all props', () => {
     const tree = shallow(<MultipleSelectField
       id="test"
+      inFormLayout
       isLabelVisible={false}
       label="label"
       layout="horizontal"

--- a/src/lib/components/ui/MultipleSelectField/tests/__snapshots__/MultipleSelectField.test.jsx.snap
+++ b/src/lib/components/ui/MultipleSelectField/tests/__snapshots__/MultipleSelectField.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`rendering renders correctly mandatory props only 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -53,6 +54,7 @@ exports[`rendering renders correctly only one option 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -95,6 +97,7 @@ exports[`rendering renders correctly with all props 1`] = `
 <label
   className="root
         isRootFullWidth
+        isRootInFormLayout
         rootLayoutHorizontal
         isRootRequired
         rootSizeLarge
@@ -159,6 +162,7 @@ exports[`rendering renders correctly with one selected option 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -211,6 +215,7 @@ exports[`rendering renders correctly with one selected option 1`] = `
 exports[`rendering renders correctly with two selected options 1`] = `
 <label
   className="root
+        
         
         rootLayoutVertical
         

--- a/src/lib/components/ui/Radio/Radio.jsx
+++ b/src/lib/components/ui/Radio/Radio.jsx
@@ -5,6 +5,8 @@ import styles from './Radio.scss';
 
 const Radio = (props) => {
   let labelClass = styles.label;
+  let rootInFormLayoutClass = '';
+  let rootLayoutClass = '';
   let rootValidationStateClass = '';
 
   if (props.isLabelVisible) {
@@ -13,6 +15,14 @@ const Radio = (props) => {
     }
   } else {
     labelClass = styles.isLabelHidden;
+  }
+
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
+  }
+
+  if (props.layout === 'horizontal') {
+    rootLayoutClass = styles.isRootLayoutHorizontal;
   }
 
   if (props.validationState === 'invalid') {
@@ -25,14 +35,16 @@ const Radio = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'description', 'disabled', 'error', 'id', 'isLabelVisible',
-      'label', 'options', 'required', 'validationState', 'value'],
+    ['changeHandler', 'description', 'disabled', 'error', 'id', 'inFormLayout', 'isLabelVisible',
+      'label', 'layout', 'options', 'required', 'validationState', 'value'],
   );
 
   return (
     <div
       className={`
         ${styles.root}
+        ${rootInFormLayoutClass}
+        ${rootLayoutClass}
         ${rootValidationStateClass}
       `.trim()}
     >
@@ -99,7 +111,9 @@ Radio.defaultProps = {
   description: null,
   disabled: false,
   error: null,
+  inFormLayout: false,
   isLabelVisible: true,
+  layout: 'vertical',
   required: false,
   validationState: null,
   value: undefined,
@@ -111,8 +125,10 @@ Radio.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,
+  layout: PropTypes.oneOf(['horizontal', 'vertical']),
   options: PropTypes.arrayOf(PropTypes.shape({
     disabled: PropTypes.bool,
     label: PropTypes.string.isRequired,

--- a/src/lib/components/ui/Radio/Radio.scss
+++ b/src/lib/components/ui/Radio/Radio.scss
@@ -9,6 +9,8 @@
 }
 
 .label {
+  @include form-field-label();
+
   display: inline-block;
   margin-bottom: 0.25rem;
 }
@@ -48,6 +50,7 @@
 }
 
 .radioLabel {
+  @include form-field-label();
   @include form-checkbox-radio-label-styles($checkbox-radio-label-height, $checkbox-radio-padding-left);
 }
 
@@ -150,4 +153,12 @@
 
 .isRootStateWarning .input:checked + .radioLabel::before {
   box-shadow: inset 0 0 0 6px $form-warning-color;
+}
+
+.isRootLayoutHorizontal {
+  position: relative; // Just set something until the component is refactored (#20).
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }

--- a/src/lib/components/ui/Radio/tests/Radio.test.jsx
+++ b/src/lib/components/ui/Radio/tests/Radio.test.jsx
@@ -63,6 +63,8 @@ describe('rendering', () => {
       label="label"
       disabled
       id="test"
+      inFormLayout
+      layout="horizontal"
       value="ch1"
       description="some help"
       error="some error"

--- a/src/lib/components/ui/Radio/tests/__snapshots__/Radio.test.jsx.snap
+++ b/src/lib/components/ui/Radio/tests/__snapshots__/Radio.test.jsx.snap
@@ -150,6 +150,8 @@ exports[`rendering renders correctly only one option and hidden label 1`] = `
 exports[`rendering renders correctly with all props 1`] = `
 <div
   className="root
+        isRootInFormLayout
+        isRootLayoutHorizontal
         isRootStateWarning"
 >
   <div

--- a/src/lib/components/ui/SelectField/SelectField.jsx
+++ b/src/lib/components/ui/SelectField/SelectField.jsx
@@ -7,6 +7,7 @@ import styles from './SelectField.scss';
 export const SelectField = (props) => {
   let labelVisibilityClass = '';
   let rootFullWidthClass = '';
+  let rootInFormLayoutClass = '';
   let rootLayoutClass = '';
   let rootRequiredClass = '';
   let rootSizeClass = '';
@@ -19,6 +20,10 @@ export const SelectField = (props) => {
 
   if (props.fullWidth) {
     rootFullWidthClass = styles.isRootFullWidth;
+  }
+
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
   }
 
   if (props.layout === 'horizontal') {
@@ -55,7 +60,7 @@ export const SelectField = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'isLabelVisible',
+    ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'inFormLayout', 'isLabelVisible',
       'label', 'layout', 'options', 'required', 'size', 'validationState', 'value', 'variant'],
   );
 
@@ -64,6 +69,7 @@ export const SelectField = (props) => {
       className={(`
         ${styles.root}
         ${rootFullWidthClass}
+        ${rootInFormLayoutClass}
         ${rootLayoutClass}
         ${rootRequiredClass}
         ${rootSizeClass}
@@ -131,6 +137,7 @@ SelectField.defaultProps = {
   forwardedRef: undefined,
   fullWidth: false,
   helperText: null,
+  inFormLayout: false,
   isLabelVisible: true,
   layout: 'vertical',
   required: false,
@@ -147,6 +154,7 @@ SelectField.propTypes = {
   fullWidth: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,
   layout: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/src/lib/components/ui/SelectField/SelectField.scss
+++ b/src/lib/components/ui/SelectField/SelectField.scss
@@ -11,6 +11,10 @@
   @include form-field-horizontal-neighbor();
 }
 
+.label {
+  @include form-field-label();
+}
+
 .inputContainer {
   @include form-field-input-container();
 }
@@ -84,6 +88,10 @@
 .isRootFullWidth {
   @include form-field-full-width();
   @include form-field-vertical-neighbor();
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }
 
 // Sizes

--- a/src/lib/components/ui/SelectField/tests/SelectField.test.jsx
+++ b/src/lib/components/ui/SelectField/tests/SelectField.test.jsx
@@ -45,6 +45,7 @@ describe('rendering', () => {
   it('renders correctly with all props', () => {
     const tree = shallow(<SelectField
       id="test"
+      inFormLayout
       isLabelVisible={false}
       label="label"
       layout="horizontal"

--- a/src/lib/components/ui/SelectField/tests/__snapshots__/SelectField.test.jsx.snap
+++ b/src/lib/components/ui/SelectField/tests/__snapshots__/SelectField.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`rendering renders correctly mandatory props only 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -58,6 +59,7 @@ exports[`rendering renders correctly only one option 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -105,6 +107,7 @@ exports[`rendering renders correctly with all props 1`] = `
 <label
   className="root
         isRootFullWidth
+        isRootInFormLayout
         rootLayoutHorizontal
         isRootRequired
         rootSizeLarge

--- a/src/lib/components/ui/TextArea/TextArea.jsx
+++ b/src/lib/components/ui/TextArea/TextArea.jsx
@@ -7,6 +7,7 @@ import styles from './TextArea.scss';
 export const TextArea = (props) => {
   let labelVisibilityClass = '';
   let rootFullWidthClass = '';
+  let rootInFormLayoutClass = '';
   let rootLayoutClass = '';
   let rootRequiredClass = '';
   let rootSizeClass = '';
@@ -19,6 +20,10 @@ export const TextArea = (props) => {
 
   if (props.fullWidth) {
     rootFullWidthClass = styles.isRootFullWidth;
+  }
+
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
   }
 
   if (props.layout === 'horizontal') {
@@ -55,7 +60,7 @@ export const TextArea = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'cols', 'disabled', 'fullWidth', 'helperText', 'id', 'isLabelVisible',
+    ['changeHandler', 'cols', 'disabled', 'fullWidth', 'helperText', 'id', 'inFormLayout', 'isLabelVisible',
       'label', 'layout', 'placeholder', 'required', 'rows', 'size', 'validationState', 'value', 'variant'],
   );
 
@@ -64,6 +69,7 @@ export const TextArea = (props) => {
       className={(`
         ${styles.root}
         ${rootFullWidthClass}
+        ${rootInFormLayoutClass}
         ${rootLayoutClass}
         ${rootRequiredClass}
         ${rootSizeClass}
@@ -119,6 +125,7 @@ TextArea.defaultProps = {
   forwardedRef: undefined,
   fullWidth: false,
   helperText: null,
+  inFormLayout: false,
   isLabelVisible: true,
   layout: 'vertical',
   placeholder: null,
@@ -138,6 +145,7 @@ TextArea.propTypes = {
   fullWidth: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,
   layout: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/src/lib/components/ui/TextArea/TextArea.scss
+++ b/src/lib/components/ui/TextArea/TextArea.scss
@@ -11,6 +11,10 @@
   @include form-field-horizontal-neighbor();
 }
 
+.label {
+  @include form-field-label();
+}
+
 .inputContainer {
   @include form-field-input-container();
 }
@@ -71,6 +75,10 @@
 .isRootFullWidth {
   @include form-field-full-width();
   @include form-field-vertical-neighbor();
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }
 
 // Sizes

--- a/src/lib/components/ui/TextArea/tests/TextArea.test.jsx
+++ b/src/lib/components/ui/TextArea/tests/TextArea.test.jsx
@@ -29,6 +29,7 @@ describe('rendering', () => {
       cols={10}
       id="test"
       helperText="some help"
+      inFormLayout
       isLabelVisible={false}
       label="label"
       layout="horizontal"

--- a/src/lib/components/ui/TextArea/tests/__snapshots__/TextArea.test.jsx.snap
+++ b/src/lib/components/ui/TextArea/tests/__snapshots__/TextArea.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`rendering renders correctly mandatory props only 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -39,6 +40,7 @@ exports[`rendering renders correctly with all props 1`] = `
 <label
   className="root
         isRootFullWidth
+        isRootInFormLayout
         rootLayoutHorizontal
         isRootRequired
         rootSizeLarge
@@ -84,6 +86,7 @@ exports[`rendering renders correctly with all props 1`] = `
 exports[`rendering renders correctly with hidden label 1`] = `
 <label
   className="root
+        
         
         rootLayoutVertical
         

--- a/src/lib/components/ui/TextField/TextField.jsx
+++ b/src/lib/components/ui/TextField/TextField.jsx
@@ -9,6 +9,7 @@ export const TextField = (props) => {
 
   let labelVisibilityClass = '';
   let rootFullWidthClass = '';
+  let rootInFormLayoutClass = '';
   let rootLayoutClass = '';
   let rootRequiredClass = '';
   let rootSizeClass = '';
@@ -22,6 +23,10 @@ export const TextField = (props) => {
 
   if (props.fullWidth) {
     rootFullWidthClass = styles.isRootFullWidth;
+  }
+
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
   }
 
   if (props.inputSize && props.inputSize <= SMALL_INPUT_SIZE) {
@@ -62,7 +67,7 @@ export const TextField = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'inputSize', 'isLabelVisible',
+    ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'inFormLayout', 'inputSize', 'isLabelVisible',
       'label', 'layout', 'placeholder', 'required', 'size', 'type', 'validationState', 'value', 'variant'],
   );
 
@@ -71,6 +76,7 @@ export const TextField = (props) => {
       className={(`
         ${styles.root}
         ${rootFullWidthClass}
+        ${rootInFormLayoutClass}
         ${rootLayoutClass}
         ${rootRequiredClass}
         ${rootSizeClass}
@@ -126,6 +132,7 @@ TextField.defaultProps = {
   forwardedRef: undefined,
   fullWidth: false,
   helperText: null,
+  inFormLayout: false,
   inputSize: null,
   isLabelVisible: true,
   layout: 'vertical',
@@ -145,6 +152,7 @@ TextField.propTypes = {
   fullWidth: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   inputSize: PropTypes.number,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,

--- a/src/lib/components/ui/TextField/TextField.scss
+++ b/src/lib/components/ui/TextField/TextField.scss
@@ -11,6 +11,10 @@
   @include form-field-horizontal-neighbor();
 }
 
+.label {
+  @include form-field-label();
+}
+
 .inputContainer {
   @include form-field-input-container();
 }
@@ -71,6 +75,10 @@
 .isRootFullWidth {
   @include form-field-full-width();
   @include form-field-vertical-neighbor();
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }
 
 .hasRootSmallInput {

--- a/src/lib/components/ui/TextField/__tests__/TextField.test.jsx
+++ b/src/lib/components/ui/TextField/__tests__/TextField.test.jsx
@@ -28,6 +28,7 @@ describe('rendering', () => {
     const tree = shallow(<TextField
       id="test"
       helperText="some help"
+      inFormLayout
       isLabelVisible={false}
       label="label"
       layout="horizontal"

--- a/src/lib/components/ui/TextField/__tests__/__snapshots__/TextField.test.jsx.snap
+++ b/src/lib/components/ui/TextField/__tests__/__snapshots__/TextField.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`rendering renders correctly mandatory props only 1`] = `
 <label
   className="root
         
+        
         rootLayoutVertical
         
         rootSizeMedium
@@ -40,6 +41,7 @@ exports[`rendering renders correctly with all props 1`] = `
 <label
   className="root
         isRootFullWidth
+        isRootInFormLayout
         rootLayoutHorizontal
         isRootRequired
         rootSizeLarge
@@ -86,6 +88,7 @@ exports[`rendering renders correctly with all props 1`] = `
 exports[`rendering renders correctly with hidden label 1`] = `
 <label
   className="root
+        
         
         rootLayoutVertical
         

--- a/src/lib/components/ui/Toggle/Toggle.jsx
+++ b/src/lib/components/ui/Toggle/Toggle.jsx
@@ -7,6 +7,8 @@ import styles from './Toggle.scss';
 export const Toggle = (props) => {
   let labelVisibilityClass = '';
   let labelPositionClass = '';
+  let rootInFormLayoutClass = '';
+  let rootLayoutClass = '';
   let rootValidationStateClass = '';
 
   if (!props.isLabelVisible) {
@@ -19,6 +21,14 @@ export const Toggle = (props) => {
     labelPositionClass = styles.labelPositionAfter;
   }
 
+  if (props.inFormLayout) {
+    rootInFormLayoutClass = styles.isRootInFormLayout;
+  }
+
+  if (props.layout === 'horizontal') {
+    rootLayoutClass = styles.isRootLayoutHorizontal;
+  }
+
   if (props.validationState === 'invalid') {
     rootValidationStateClass = styles.isRootStateInvalid;
   } else if (props.validationState === 'valid') {
@@ -29,8 +39,8 @@ export const Toggle = (props) => {
 
   const propsToTransfer = transferProps(
     props,
-    ['changeHandler', 'checked', 'description', 'disabled', 'error', 'id', 'isLabelVisible',
-      'label', 'labelPosition', 'required', 'validationState', 'value'],
+    ['changeHandler', 'checked', 'description', 'disabled', 'error', 'id', 'inFormLayout', 'isLabelVisible',
+      'label', 'labelPosition', 'layout', 'required', 'validationState', 'value'],
   );
 
   return (
@@ -38,6 +48,8 @@ export const Toggle = (props) => {
       className={(`
         ${styles.root}
         ${labelPositionClass}
+        ${rootInFormLayoutClass}
+        ${rootLayoutClass}
         ${rootValidationStateClass}
       `).trim()}
     >
@@ -99,8 +111,10 @@ Toggle.defaultProps = {
   disabled: false,
   error: null,
   forwardedRef: undefined,
+  inFormLayout: false,
   isLabelVisible: true,
   labelPosition: 'after',
+  layout: 'vertical',
   required: false,
   validationState: null,
   value: undefined,
@@ -114,9 +128,11 @@ Toggle.propTypes = {
   error: PropTypes.string,
   forwardedRef: PropTypes.func,
   id: PropTypes.string.isRequired,
+  inFormLayout: PropTypes.bool,
   isLabelVisible: PropTypes.bool,
   label: PropTypes.string.isRequired,
   labelPosition: PropTypes.oneOf(['before', 'after']),
+  layout: PropTypes.oneOf(['horizontal', 'vertical']),
   required: PropTypes.bool,
   validationState: PropTypes.oneOf(['invalid', 'valid', 'warning']),
   value: PropTypes.oneOfType([

--- a/src/lib/components/ui/Toggle/Toggle.scss
+++ b/src/lib/components/ui/Toggle/Toggle.scss
@@ -41,6 +41,7 @@
 }
 
 .label {
+  @include form-field-label();
   @include form-checkbox-radio-label-styles($toggle-label-height, 0);
 }
 
@@ -259,4 +260,12 @@
 
 .isRootStateWarning .input:checked + .label::after {
   background-image: icon-generate-checkmark($white);
+}
+
+.isRootLayoutHorizontal {
+  position: relative; // Just set something until the component is refactored (#20).
+}
+
+.isRootInFormLayout {
+  @include form-field-in-form-layout();
 }

--- a/src/lib/components/ui/Toggle/tests/Toggle.test.jsx
+++ b/src/lib/components/ui/Toggle/tests/Toggle.test.jsx
@@ -19,6 +19,8 @@ describe('rendering', () => {
       label="label"
       disabled
       id="test"
+      inFormLayout
+      layout="horizontal"
       value="value"
       description="some help"
       error="some error"

--- a/src/lib/components/ui/Toggle/tests/__snapshots__/Toggle.test.jsx.snap
+++ b/src/lib/components/ui/Toggle/tests/__snapshots__/Toggle.test.jsx.snap
@@ -41,6 +41,8 @@ exports[`rendering renders correctly with all props 1`] = `
 <div
   className="root
         labelPositionAfter
+        isRootInFormLayout
+        isRootLayoutHorizontal
         isRootStateWarning"
 >
   <label

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -5,6 +5,7 @@ export { CTA } from './components/layout/CTA';
 export { CTACenter } from './components/layout/CTA';
 export { CTAEnd } from './components/layout/CTA';
 export { CTAStart } from './components/layout/CTA';
+export { default as FormLayout } from './components/layout/FormLayout';
 export { List } from './components/layout/List';
 export { ListItem } from './components/layout/List';
 export { Media } from './components/layout/Media';

--- a/src/lib/styles/settings/_forms-theme.scss
+++ b/src/lib/styles/settings/_forms-theme.scss
@@ -15,8 +15,10 @@ $form-field-border-color: var(--rui-form-field-border-color);
 $form-field-border-radius: var(--rui-form-field-border-radius);
 $form-field-hover-border-color: var(--rui-form-field-hover-border-color);
 $form-field-focus-border-color: var(--rui-form-field-focus-border-color);
-$form-field-horizontal-label-min-width: var(--rui-form-field-horizontal-label-min-width);
 $form-field-horizontal-label-alignment: var(--rui-form-field-horizontal-label-alignment);
+$form-field-horizontal-label-min-width: var(--rui-form-field-horizontal-label-min-width);
+$form-field-horizontal-label-width: var(--rui-form-field-horizontal-label-width);
+$form-field-horizontal-full-width-label-width: var(--rui-form-field-horizontal-full-width-label-width);
 
 $form-field-variants: (
   filled: (
@@ -78,3 +80,7 @@ $form-field-sizes: (
     font-size: var(--rui-form-field-large-font-size),
   ),
 );
+
+$form-layout-horizontal-label-auto-width: var(--rui-form-layout-horizontal-label-auto-width);
+$form-layout-horizontal-label-auto-width-fallback: var(--rui-form-layout-horizontal-label-auto-width-fallback);
+$form-layout-horizontal-label-default-width: var(--rui-form-layout-horizontal-label-default-width);

--- a/src/lib/styles/settings/_layouts.scss
+++ b/src/lib/styles/settings/_layouts.scss
@@ -1,0 +1,3 @@
+@import '../tools/offset';
+
+$layout-common-bottom-offset: offset(4);

--- a/src/lib/styles/tools/_forms.deprecated.scss
+++ b/src/lib/styles/tools/_forms.deprecated.scss
@@ -1,7 +1,9 @@
 // ⚠️ Deprecated for new components.
 
 @import '../settings/borders';
+@import '../settings/forms';
 @import '../settings/forms.deprecated';
+@import '../tools/breakpoints';
 
 @mixin form-disabled-state() {
   opacity: 0.5;
@@ -98,4 +100,22 @@
   opacity: 0;
   width: $width;
   height: $height;
+}
+
+@mixin form-field-in-form-layout() {
+  @include breakpoint-up($form-field-horizontal-breakpoint) {
+    &.isRootLayoutHorizontal {
+      display: grid;
+      grid: inherit;
+      grid-template-columns: var(--rui-local-label-width-fallback) 1fr;
+      grid-template-columns: subgrid;
+      grid-column: span 2;
+    }
+
+    &.isRootLayoutHorizontal .inputWrap,
+    &.isRootLayoutHorizontal .description,
+    &.isRootLayoutHorizontal .error {
+      grid-column-start: 2;
+    }
+  }
 }

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -7,6 +7,10 @@
 @import '../transitions';
 @import 'states';
 
+@mixin form-field-label() {
+  overflow-wrap: break-word;
+}
+
 @mixin form-field-label-required() {
   &::after {
     content: $form-field-required-sign;

--- a/src/lib/styles/tools/forms/_layouts.scss
+++ b/src/lib/styles/tools/forms/_layouts.scss
@@ -1,7 +1,10 @@
-// 1. Form fields in vertical layout take as much space as they need. Labels and helper texts do
-//    *not* wrap unless forced by container of the field.
-// 2. Form fields in horizontal layout only take as much space as their label needs without being
-//    wrapped (`max-content`). Helper text is aligned below input and wrapped.
+// 1. Form fields in vertical layout take up as much space as they need. Labels and helper texts do
+//    not wrap until forced by container of the field. Min and max limits make extra long words break
+//    if necessary.
+// 2. Form fields in horizontal layout also take up only as much space as they need. Labels do not
+//    wrap until label width limit is reached (50 % of available horizontal space by default).
+//    Helper texts are aligned below input and wrapped. Beware that automatic label wrapping isn't
+//    possible with small inputs (4.).
 // 3. Define grid spacing as padding on child elements because grid areas make row and column gaps
 //    show up even when not necessary.
 // 4. When input size is small and form field layout is set to horizontal, expand helper text over
@@ -9,8 +12,15 @@
 //    very narrow column and hard to read. To prevent the helper text from growing the layout more
 //    than necessary (ie. in state without helper text) `min-content` grid sizing must be used along
 //    with disabled wrapping of label.
-// 5. Full-width horizontal form fields prefer not wrapping the label unless necessary
-//    (`max-content`).
+// 5. Full-width horizontal form fields prefer not wrapping the label until a limit is reached
+//    (50 % of available horizontal space by default, same as in 2.).
+// 6. Justify inputs to `start` in horizontal layouts to fix positioning issues with Select Fields.
+//    Reverted for full-width fields.
+// 7. When form field exists inside Form Layout, automatic margins are removed as the Form Layout
+//    takes care of proper spacing.
+// 8. Horizontal Form Layout defines the grid settings which are inherited and applied using
+//    `subgrid`. A fallback is supplied to browsers that don't support `subgrid` yet. See
+//    Form Layout styles for more.
 
 @import '../../settings/forms';
 @import '../../settings/forms-theme';
@@ -18,6 +28,8 @@
 
 @mixin form-field-layout-vertical() {
   display: inline-block; // 1.
+  min-width: 0; // 1.
+  max-width: 100%; // 1.
 
   .label {
     padding-bottom: $form-field-vertical-inner-gap;
@@ -33,7 +45,7 @@
 
   @include breakpoint-up($form-field-horizontal-breakpoint) {
     display: inline-grid; // 2.
-    grid-template-columns: max-content min-content; // 2.
+    grid-template-columns: $form-field-horizontal-label-width min-content; // 2.
     grid-template-areas:
       "label input"
       ". helpertext";
@@ -49,6 +61,7 @@
 
     .inputContainer {
       grid-area: input;
+      justify-self: start; // 6.
     }
 
     .helperText {
@@ -84,7 +97,40 @@
   @include breakpoint-up($form-field-horizontal-breakpoint) {
     &.rootLayoutHorizontal {
       display: grid;
-      grid-template-columns: max-content 1fr; // 5.
+      grid-template-columns: $form-field-horizontal-full-width-label-width 1fr; // 5.
+    }
+
+    &.rootLayoutHorizontal .inputContainer {
+      justify-self: stretch; // 6.
+    }
+  }
+}
+
+@mixin form-field-in-form-layout() {
+  &:not(:last-child),
+  &.rootLayoutHorizontal:not(:last-child) {
+    margin-right: 0; // 7.
+    margin-bottom: 0; // 7.
+  }
+
+  @include breakpoint-up($form-field-horizontal-breakpoint) {
+    &.rootLayoutHorizontal,
+    &.rootLayoutHorizontal.hasRootSmallInput {
+      grid: inherit; // 8.
+      grid-template-columns: var(--rui-local-label-width-fallback) 1fr; // 8.
+      grid-template-columns: subgrid; // 8.
+      grid-column: span 2; // 8.
+    }
+
+    &.rootLayoutHorizontal .label,
+    &.rootLayoutHorizontal .inputContainer,
+    &.rootLayoutHorizontal .helperText {
+      grid-area: unset; // 8.
+    }
+
+    &.rootLayoutHorizontal .inputContainer,
+    &.rootLayoutHorizontal .helperText {
+      grid-column-start: 2; // 8.
     }
   }
 }

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -459,6 +459,8 @@
   //    width defined in browsers unless `width` (same or smaller) is also defined.
   //    https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
   // 2. Append non-breaking space and asterisk to required filed labels.
+  // 3. Avoid using `fit-content()` for label width, it behaves differently in Chrome vs. FF for
+  //    inline grid.
 
   // Forms fields: common properties
   --rui-form-field-input-width: auto; // 1.
@@ -479,7 +481,9 @@
   --rui-form-field-hover-border-color: var(--rui-color-gray-500);
   --rui-form-field-focus-border-color: var(--rui-color-primary);
   --rui-form-field-horizontal-label-alignment: left;
-  --rui-form-field-horizontal-label-min-width: auto;
+  --rui-form-field-horizontal-label-min-width: 0;
+  --rui-form-field-horizontal-label-width: minmax(auto, 50%); // 3.
+  --rui-form-field-horizontal-full-width-label-width: fit-content(50%);
 
   // Form fields: filled variant
   --rui-form-field-filled-default-color: var(--rui-page-color);
@@ -524,6 +528,14 @@
   --rui-form-field-large-height: 2.75rem;
   --rui-form-field-large-padding: 0.5rem var(--rui-offset-4);
   --rui-form-field-large-font-size: var(--rui-typography-size-1);
+
+  //
+  // Form Layout
+  // ===========
+
+  --rui-form-layout-horizontal-label-auto-width: fit-content(50%);
+  --rui-form-layout-horizontal-label-auto-width-fallback: 10em;
+  --rui-form-layout-horizontal-label-default-width: 10em;
 
   //
   // Modal

--- a/webpack.config.lib.js
+++ b/webpack.config.lib.js
@@ -3,7 +3,7 @@ const StyleLintPlugin = require('stylelint-webpack-plugin');
 const VisualizerPlugin = require('webpack-visualizer-plugin');
 
 const MAX_DEVELOPMENT_OUTPUT_SIZE = 1250000;
-const MAX_PRODUCTION_OUTPUT_SIZE = 175000;
+const MAX_PRODUCTION_OUTPUT_SIZE = 180000;
 
 module.exports = (env, argv) => ({
   devtool: argv.mode === 'production'


### PR DESCRIPTION
- Create `FormLayout` component and make form fields ready for it
- Add support for React Fragments to `CardList` and `FormLayout`

Closes #44.

## Vertical Form Layout

![image](https://user-images.githubusercontent.com/5614085/83517215-c7312780-a4d8-11ea-80b9-37c5d4b4cd98.png)

**With FF grid inspector on:**

![image](https://user-images.githubusercontent.com/5614085/83531804-b939d180-a4ed-11ea-8531-089e20d86902.png)

## Horizontal Form Layout

### Firefox – Subgrid Solution (auto-sized column with labels)

https://caniuse.com/#feat=css-subgrid

![image](https://user-images.githubusercontent.com/5614085/83517417-242cdd80-a4d9-11ea-8700-fe37d476c819.png)

**With FF grid inspector on:**

![image](https://user-images.githubusercontent.com/5614085/83531870-ceaefb80-a4ed-11ea-8dc9-a6245f061011.png)

### Webkit – Fallback Solution (fixed-width column with labels)

![image](https://user-images.githubusercontent.com/5614085/83517238-d4e6ad00-a4d8-11ea-9988-ebed3f13b631.png)

## Edge Cases

Label width is limited to 50 % of available horizontal space.

⚠️ Maximum label width and text wrapping is not available for small input sizes. It seems to be technically impossible to have both fluid label and wrapping helper text without unwanted impact on design.

<img width="731" alt="Snímek obrazovky 2020-06-02 v 12 20 43" src="https://user-images.githubusercontent.com/5614085/83517507-46bef680-a4d9-11ea-97ad-ece71db13eea.png">

<img width="838" alt="Snímek obrazovky 2020-06-02 v 12 21 12" src="https://user-images.githubusercontent.com/5614085/83517555-5b02f380-a4d9-11ea-9a29-6307d570fb87.png">

<img width="634" alt="Snímek obrazovky 2020-06-02 v 12 20 20" src="https://user-images.githubusercontent.com/5614085/83517573-62c29800-a4d9-11ea-8b8c-3776995189c2.png">
