### PR TITLE
Improve form field sizing

### DIFF
--- a/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`rendering renders correctly 1`] = `
         rootVariantOutline"
                   htmlFor="resetEmailInput"
                   id="resetEmailInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -224,6 +225,7 @@ exports[`rendering renders correctly 2`] = `
         rootVariantOutline"
                   htmlFor="resetEmailInput"
                   id="resetEmailInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -404,6 +406,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootVariantOutline"
                   htmlFor="custom-id__resetEmailInput"
                   id="custom-id__resetEmailInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
@@ -74,6 +74,7 @@ exports[`rendering renders correctly 1`] = `
         rootVariantOutline"
                   htmlFor="usernameInput"
                   id="usernameInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -140,6 +141,7 @@ exports[`rendering renders correctly 1`] = `
         rootVariantOutline"
                   htmlFor="passwordInput"
                   id="passwordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -321,6 +323,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootVariantOutline"
                   htmlFor="custom-id__usernameInput"
                   id="custom-id__usernameInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -387,6 +390,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootVariantOutline"
                   htmlFor="custom-id__passwordInput"
                   id="custom-id__passwordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -557,6 +561,7 @@ exports[`rendering renders correctly with translations 1`] = `
         rootVariantOutline"
                   htmlFor="usernameInput"
                   id="usernameInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -623,6 +628,7 @@ exports[`rendering renders correctly with translations 1`] = `
         rootVariantOutline"
                   htmlFor="passwordInput"
                   id="passwordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -773,6 +779,7 @@ exports[`rendering renders correctly with username 1`] = `
         rootVariantOutline"
                   htmlFor="usernameInput"
                   id="usernameInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -839,6 +846,7 @@ exports[`rendering renders correctly with username 1`] = `
         rootVariantOutline"
                   htmlFor="passwordInput"
                   id="passwordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`rendering renders correctly 1`] = `
         rootVariantOutline"
                   htmlFor="newPasswordInput"
                   id="newPasswordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -138,6 +139,7 @@ exports[`rendering renders correctly 1`] = `
         rootVariantOutline"
                   htmlFor="newPasswordRepeatInput"
                   id="newPasswordRepeatInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -317,6 +319,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootVariantOutline"
                   htmlFor="custom-id__newPasswordInput"
                   id="custom-id__newPasswordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -383,6 +386,7 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         rootVariantOutline"
                   htmlFor="custom-id__newPasswordRepeatInput"
                   id="custom-id__newPasswordRepeatInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -550,6 +554,7 @@ exports[`rendering renders correctly with translations 1`] = `
         rootVariantOutline"
                   htmlFor="newPasswordInput"
                   id="newPasswordInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"
@@ -616,6 +621,7 @@ exports[`rendering renders correctly with translations 1`] = `
         rootVariantOutline"
                   htmlFor="newPasswordRepeatInput"
                   id="newPasswordRepeatInput__label"
+                  style={Object {}}
                 >
                   <div
                     className="label"

--- a/src/lib/components/ui/TextField/TextField.jsx
+++ b/src/lib/components/ui/TextField/TextField.jsx
@@ -65,6 +65,16 @@ export const TextField = (props) => {
     rootVariantClass = styles.rootVariantOutline;
   }
 
+  const inlineStyle = (inputSize) => {
+    const style = {};
+
+    if (inputSize) {
+      style['--rui-custom-input-size'] = inputSize;
+    }
+
+    return style;
+  };
+
   const propsToTransfer = transferProps(
     props,
     ['changeHandler', 'disabled', 'fullWidth', 'helperText', 'id', 'inFormLayout', 'inputSize', 'isLabelVisible',
@@ -86,6 +96,7 @@ export const TextField = (props) => {
       `).trim()}
       htmlFor={props.id}
       id={`${props.id}__label`}
+      style={inlineStyle(props.inputSize)}
     >
       <div
         className={(`

--- a/src/lib/components/ui/TextField/__tests__/__snapshots__/TextField.test.jsx.snap
+++ b/src/lib/components/ui/TextField/__tests__/__snapshots__/TextField.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`rendering renders correctly mandatory props only 1`] = `
         rootVariantOutline"
   htmlFor="test"
   id="test__label"
+  style={Object {}}
 >
   <div
     className="label"
@@ -50,6 +51,11 @@ exports[`rendering renders correctly with all props 1`] = `
         rootVariantFilled"
   htmlFor="test"
   id="test__label"
+  style={
+    Object {
+      "--rui-custom-input-size": 3,
+    }
+  }
 >
   <div
     className="label
@@ -98,6 +104,7 @@ exports[`rendering renders correctly with hidden label 1`] = `
         rootVariantOutline"
   htmlFor="test"
   id="test__label"
+  style={Object {}}
 >
   <div
     className="label

--- a/src/lib/styles/settings/_forms-theme.scss
+++ b/src/lib/styles/settings/_forms-theme.scss
@@ -66,17 +66,20 @@ $form-field-states: (
 $form-field-sizes: (
   small: (
     height: var(--rui-form-field-small-height),
-    padding: var(--rui-form-field-small-padding),
+    padding-vertical: var(--rui-form-field-small-padding-vertical),
+    padding-horizontal: var(--rui-form-field-small-padding-horizontal),
     font-size: var(--rui-form-field-small-font-size),
   ),
   medium: (
     height: var(--rui-form-field-medium-height),
-    padding: var(--rui-form-field-medium-padding),
+    padding-vertical: var(--rui-form-field-medium-padding-vertical),
+    padding-horizontal: var(--rui-form-field-medium-padding-horizontal),
     font-size: var(--rui-form-field-medium-font-size),
   ),
   large: (
     height: var(--rui-form-field-large-height),
-    padding: var(--rui-form-field-large-padding),
+    padding-vertical: var(--rui-form-field-large-padding-vertical),
+    padding-horizontal: var(--rui-form-field-large-padding-horizontal),
     font-size: var(--rui-form-field-large-font-size),
   ),
 );

--- a/src/lib/styles/settings/_forms.scss
+++ b/src/lib/styles/settings/_forms.scss
@@ -4,7 +4,6 @@
 @import 'offsets';
 @import 'typography';
 
-$form-field-label-line-height: 1.5rem;
 $form-field-font-family: $typography-font-family-base;
 $form-field-font-weight: map-get($typography-font-weight-values, regular);
 $form-field-line-height: 1.5rem; // 1.

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -1,6 +1,7 @@
 // 1. Get ready for positioning of bottom line and caret.
 // 2. Override hover style of disabled input.
-// 3. Always prefer the `size` attribute when defined.
+// 3. Always prefer the `size` attribute when defined. Use CSS for sizing to normalize resulting
+//    width across browsers.
 // 4. Let inputs properly fit various layout scenarios.
 // 5. Leave out space for Select Field caret.
 
@@ -67,7 +68,13 @@
 
 @mixin form-field-input-text() {
   &[size] {
-    width: auto; // 3.
+    width:
+      calc(
+        1ch * var(--rui-custom-input-size)
+        + 2 * var(--rui-local-padding-horizontal)
+        + 2 * #{$form-field-border-width}
+      ); // 3.
+
     min-width: auto; // 3.
   }
 }

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -1,6 +1,7 @@
 // 1. Get ready for positioning of bottom line and caret.
 // 2. Override hover style of disabled input.
 // 3. Always prefer the `size` attribute when defined.
+// 4. Let inputs properly fit various layout scenarios.
 
 @import '../../settings/forms';
 @import '../../settings/forms-theme';
@@ -21,6 +22,8 @@
 @mixin form-field-input-container() {
   position: relative; // 1.
   display: inline-flex;
+  min-width: 0; // 4.
+  max-width: 100%; // 4.
 }
 
 @mixin form-field-input() {
@@ -28,6 +31,7 @@
 
   width: $form-field-input-width;
   min-width: $form-field-input-min-width;
+  max-width: 100%; // 4.
   font-weight: $form-field-font-weight;
   line-height: $form-field-line-height;
   font-family: $form-field-font-family;

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -2,9 +2,11 @@
 // 2. Override hover style of disabled input.
 // 3. Always prefer the `size` attribute when defined.
 // 4. Let inputs properly fit various layout scenarios.
+// 5. Leave out space for Select Field caret.
 
 @import '../../settings/forms';
 @import '../../settings/forms-theme';
+@import '../../tools/offset';
 @import '../transitions';
 @import 'states';
 
@@ -32,7 +34,10 @@
   width: $form-field-input-width;
   min-width: $form-field-input-min-width;
   max-width: 100%; // 4.
+  height: var(--rui-local-height);
+  padding: var(--rui-local-padding-vertical) var(--rui-local-padding-horizontal);
   font-weight: $form-field-font-weight;
+  font-size: var(--rui-local-font-size);
   line-height: $form-field-line-height;
   font-family: $form-field-font-family;
   vertical-align: middle;
@@ -76,7 +81,7 @@
 }
 
 @mixin form-field-input-select() {
-  padding-right: calc(#{$form-field-caret-size} - 2 * #{$form-field-border-width} + #{map-get($offset-values, 2)});
+  padding-right: calc(#{$form-field-caret-size} + #{offset(2)}); // 5.
   appearance: none;
 
   &::-ms-expand {

--- a/src/lib/styles/tools/forms/_sizes.scss
+++ b/src/lib/styles/tools/forms/_sizes.scss
@@ -1,9 +1,4 @@
-// 1. Unfortunately, `align-items: baseline` does not work with empty inputs in Safari,
-//    so we must emulate this behavior and align label text with input text manually.
-
-@import '../../settings/forms';
 @import '../../settings/forms-theme';
-@import '../breakpoints';
 
 @mixin form-field-size($size, $is-multiline: false) {
   $size-properties: map-get($form-field-sizes, $size);
@@ -15,18 +10,11 @@
     }
 
     @else {
-      height: map-get($size-properties, height);
+      --rui-local-height: #{map-get($size-properties, height)};
     }
 
-    padding: map-get($size-properties, padding);
-    font-size: map-get($size-properties, font-size);
-  }
-
-  &.rootLayoutHorizontal {
-    @include breakpoint-up($form-field-horizontal-breakpoint) {
-      .label {
-        margin-top: ($form-field-line-height - $form-field-label-line-height) / 2; // 1.
-      }
-    }
+    --rui-local-padding-vertical: #{map-get($size-properties, padding-vertical)};
+    --rui-local-padding-horizontal: #{map-get($size-properties, padding-horizontal)};
+    --rui-local-font-size: #{map-get($size-properties, font-size)};
   }
 }

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -517,17 +517,20 @@
 
   // Form fields: sizes: small
   --rui-form-field-small-height: 1.75rem;
-  --rui-form-field-small-padding: 0 var(--rui-offset-2);
+  --rui-form-field-small-padding-vertical: 0;
+  --rui-form-field-small-padding-horizontal: var(--rui-offset-2);
   --rui-form-field-small-font-size: var(--rui-typography-size-small);
 
   // Form fields: sizes: medium
   --rui-form-field-medium-height: 2.25rem;
-  --rui-form-field-medium-padding: 0.25rem var(--rui-offset-3);
+  --rui-form-field-medium-padding-vertical: 0.25rem;
+  --rui-form-field-medium-padding-horizontal: var(--rui-offset-3);
   --rui-form-field-medium-font-size: var(--rui-typography-size-0);
 
   // Form fields: sizes: large
   --rui-form-field-large-height: 2.75rem;
-  --rui-form-field-large-padding: 0.5rem var(--rui-offset-4);
+  --rui-form-field-large-padding-vertical: 0.5rem;
+  --rui-form-field-large-padding-horizontal: var(--rui-offset-4);
   --rui-form-field-large-font-size: var(--rui-typography-size-1);
 
   //


### PR DESCRIPTION
- Limit width of form fields to prevent overflowing their container (closes #102)
- Handle custom input size with CSS to fix different behaviour across browsers (closes #101)
