### PR TITLE
Enable `FormLayoutCustomField` to be full-width

### DIFF
--- a/src/lib/components/layout/FormLayout/FormLayoutCustomField.jsx
+++ b/src/lib/components/layout/FormLayout/FormLayoutCustomField.jsx
@@ -4,6 +4,7 @@ import styles from './FormLayoutCustomField.scss';
 
 const FormLayoutCustomField = ({
   children,
+  fullWidth,
   id,
   label,
   layout,
@@ -12,6 +13,7 @@ const FormLayoutCustomField = ({
     id={id}
     className={`
       ${styles.root}
+      ${fullWidth ? styles.isRootFullWidth : ''}
       ${layout === 'vertical' ? styles.rootLayoutVertical : styles.rootLayoutHorizontal}
     `.trim()}
   >
@@ -34,6 +36,7 @@ const FormLayoutCustomField = ({
 
 FormLayoutCustomField.defaultProps = {
   children: null,
+  fullWidth: false,
   id: undefined,
   label: null,
   layout: 'vertical',
@@ -41,6 +44,7 @@ FormLayoutCustomField.defaultProps = {
 
 FormLayoutCustomField.propTypes = {
   children: PropTypes.node,
+  fullWidth: PropTypes.bool,
   id: PropTypes.string,
   label: PropTypes.string,
   layout: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/src/lib/components/layout/FormLayout/FormLayoutCustomField.scss
+++ b/src/lib/components/layout/FormLayout/FormLayoutCustomField.scss
@@ -21,6 +21,10 @@
   width: auto;
 }
 
+.isRootFullWidth .field {
+  justify-self: stretch;
+}
+
 .root.rootLayoutHorizontal {
   @include breakpoint-up($form-field-horizontal-breakpoint) {
     grid-template-columns: var(--rui-local-label-width-fallback) 1fr;

--- a/src/lib/components/layout/FormLayout/__tests__/FormLayoutCustomField.test.jsx
+++ b/src/lib/components/layout/FormLayout/__tests__/FormLayoutCustomField.test.jsx
@@ -28,6 +28,7 @@ describe('rendering', () => {
   it('renders correctly with all props', () => {
     const tree = shallow((
       <FormLayoutCustomField
+        fullWidth
         label="Label"
         id="my-custom-field"
         layout="horizontal"

--- a/src/lib/components/layout/FormLayout/__tests__/__snapshots__/FormLayoutCustomField.test.jsx.snap
+++ b/src/lib/components/layout/FormLayout/__tests__/__snapshots__/FormLayoutCustomField.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`rendering renders correctly with a single child 1`] = `
 <div
   className="root
+      
       rootLayoutVertical"
 >
   <div
@@ -18,6 +19,7 @@ exports[`rendering renders correctly with a single child 1`] = `
 exports[`rendering renders correctly with all props 1`] = `
 <div
   className="root
+      isRootFullWidth
       rootLayoutHorizontal"
   id="my-custom-field"
 >
@@ -47,6 +49,7 @@ exports[`rendering renders correctly with all props 1`] = `
 exports[`rendering renders correctly with multiple children 1`] = `
 <div
   className="root
+      
       rootLayoutVertical"
 >
   <div

--- a/src/lib/styles/tools/forms/_layouts.scss
+++ b/src/lib/styles/tools/forms/_layouts.scss
@@ -39,6 +39,7 @@
 
   .field {
     width: min-content; // 3.
+    max-width: 100%; // 3.
   }
 
   .helperText {


### PR DESCRIPTION
This is now possible (`Alert` is able to fill available width):

![image](https://user-images.githubusercontent.com/5614085/89522912-4b0dd580-d7e2-11ea-806f-361fa9c9acab.png)
