### PR TITLE
Fix icon-only buttons in loading state

### DIFF
--- a/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/ForgotPassword.test.jsx.snap
@@ -134,7 +134,6 @@ exports[`rendering renders correctly 1`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -291,7 +290,6 @@ exports[`rendering renders correctly 2`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -479,7 +477,6 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 disabled={false}
                 id="custom-id__resetPasswordButton"
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/Login.test.jsx.snap
@@ -207,7 +207,6 @@ exports[`rendering renders correctly 1`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -467,7 +466,6 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 disabled={false}
                 id="custom-id__signInButton"
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -710,7 +708,6 @@ exports[`rendering renders correctly with translations 1`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -936,7 +933,6 @@ exports[`rendering renders correctly with username 1`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span

--- a/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
+++ b/src/lib/components/screens/Login/__tests__/__snapshots__/NewPassword.test.jsx.snap
@@ -205,7 +205,6 @@ exports[`rendering renders correctly 1`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -463,7 +462,6 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                 disabled={false}
                 id="custom-id__changePasswordButton"
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span
@@ -703,7 +701,6 @@ exports[`rendering renders correctly with translations 1`] = `
         isRootBlock"
                 disabled={false}
                 onClick={null}
-                title={null}
                 type="submit"
               >
                 <span

--- a/src/lib/components/ui/Button/Button.jsx
+++ b/src/lib/components/ui/Button/Button.jsx
@@ -31,6 +31,7 @@ export const Button = (props) => {
   let blockClass = '';
   let groupedClass = '';
   let labelVisibilityClass = '';
+  let loadingClass = '';
 
   if (priority === 'default') {
     priorityClass = styles.priorityDefault;
@@ -78,6 +79,10 @@ export const Button = (props) => {
     } else if (labelVisibility === 'none') {
       labelVisibilityClass = styles.withLabelHidden;
     }
+
+    if (loadingIcon) {
+      loadingClass = styles.isRootLoading;
+    }
   }
 
   const propsToTransfer = transferProps(
@@ -97,12 +102,12 @@ export const Button = (props) => {
         ${blockClass}
         ${groupedClass}
         ${labelVisibilityClass}
+        ${loadingClass}
       `).trim()}
       disabled={disabled || !!loadingIcon}
       id={id}
       onClick={clickHandler}
       ref={forwardedRef}
-      title={labelVisibility === 'all' ? null : label}
       type={type}
     >
       {priority !== 'link' && startCorner && (

--- a/src/lib/components/ui/Button/_base.scss
+++ b/src/lib/components/ui/Button/_base.scss
@@ -115,11 +115,27 @@
   }
 }
 
-.withLabelHidden .loadingIcon,
-.withLabelHiddenMobile .loadingIcon {
-  display: none;
+.withLabelHidden.isRootLoading .loadingIcon,
+.withLabelHiddenMobile.isRootLoading .loadingIcon {
+  margin-left: 0;
+}
 
+.withLabelHidden.isRootLoading .beforeLabel,
+.withLabelHidden.isRootLoading .afterLabel,
+.withLabelHiddenMobile.isRootLoading .beforeLabel,
+.withLabelHiddenMobile.isRootLoading .afterLabel {
+  display: none;
+}
+
+.withLabelHiddenMobile.isRootLoading .beforeLabel,
+.withLabelHiddenMobile.isRootLoading .afterLabel {
   @include breakpoint-up($button-breakpoint) {
-    display: initial;
+    display: flex;
+  }
+}
+
+.withLabelHiddenMobile.isRootLoading .loadingIcon {
+  @include breakpoint-up($button-breakpoint) {
+    margin-left: $button-icon-offset;
   }
 }

--- a/src/lib/components/ui/Button/tests/__snapshots__/Button.test.jsx.snap
+++ b/src/lib/components/ui/Button/tests/__snapshots__/Button.test.jsx.snap
@@ -8,7 +8,6 @@ exports[`rendering renders correctly flat 1`] = `
         variantPrimary"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span
@@ -30,7 +29,6 @@ exports[`rendering renders correctly label visibility 1`] = `
         withLabelHidden"
   disabled={false}
   onClick={null}
-  title="button"
   type="button"
 >
   <span
@@ -49,7 +47,6 @@ exports[`rendering renders correctly mandatory props only 1`] = `
         variantPrimary"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span
@@ -66,7 +63,6 @@ exports[`rendering renders correctly priority \`link\` 1`] = `
         priorityLink"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span
@@ -84,7 +80,6 @@ exports[`rendering renders correctly priority \`link\` with all props 1`] = `
   disabled={true}
   id="custom-id"
   onClick={null}
-  title="link"
   type="button"
 >
   <span
@@ -118,7 +113,6 @@ exports[`rendering renders correctly priority 1`] = `
         variantPrimary"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span
@@ -137,7 +131,6 @@ exports[`rendering renders correctly size 1`] = `
         variantPrimary"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span
@@ -156,7 +149,6 @@ exports[`rendering renders correctly variant 1`] = `
         variantSuccess"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span
@@ -175,11 +167,11 @@ exports[`rendering renders correctly with all props 1`] = `
         variantSuccess
         isRootBlock
         isRootGrouped
-        withLabelHiddenMobile"
+        withLabelHiddenMobile
+        isRootLoading"
   disabled={true}
   id="custom-id"
   onClick={null}
-  title="button"
   type="button"
 >
   <span
@@ -238,7 +230,6 @@ exports[`rendering renders correctly with icon 1`] = `
         variantPrimary"
   disabled={false}
   onClick={null}
-  title={null}
   type="button"
 >
   <span

--- a/src/lib/components/ui/Modal/__tests__/__snapshots__/Modal.test.jsx.snap
+++ b/src/lib/components/ui/Modal/__tests__/__snapshots__/Modal.test.jsx.snap
@@ -253,7 +253,6 @@ exports[`rendering renders correctly with all props except translations 1`] = `
         variantPrimary"
                         disabled={false}
                         onClick={[Function]}
-                        title={null}
                         type="button"
                       >
                         <span
@@ -303,7 +302,6 @@ exports[`rendering renders correctly with all props except translations 1`] = `
                         disabled={false}
                         id="custom-id__closeModalFooterButton"
                         onClick={[Function]}
-                        title={null}
                         type="button"
                       >
                         <span
@@ -563,7 +561,11 @@ exports[`rendering renders correctly with all props except translations and with
                             class="root
         priorityDefault
         sizeMedium
-        variantPrimary"
+        variantPrimary
+        
+        
+        
+        isRootLoading"
                             disabled=""
                             type="button"
                           >
@@ -600,10 +602,13 @@ exports[`rendering renders correctly with all props except translations and with
                         className="root
         priorityDefault
         sizeMedium
-        variantPrimary"
+        variantPrimary
+        
+        
+        
+        isRootLoading"
                         disabled={true}
                         onClick={[Function]}
-                        title={null}
                         type="button"
                       >
                         <span
@@ -660,7 +665,6 @@ exports[`rendering renders correctly with all props except translations and with
                         disabled={false}
                         id="custom-id__closeModalFooterButton"
                         onClick={[Function]}
-                        title={null}
                         type="button"
                       >
                         <span
@@ -1253,7 +1257,6 @@ exports[`rendering renders correctly with translations 1`] = `
         variantPrimary"
                         disabled={false}
                         onClick={[Function]}
-                        title={null}
                         type="button"
                       >
                         <span


### PR DESCRIPTION
It was broken and it's fixed 🤷‍♂️. Seriously, there was a problem with loading icon overflowing the button when only icon is shown. Solved by hiding the original icon when loading:

![image](https://user-images.githubusercontent.com/5614085/91967142-1888c700-ed13-11ea-9e4e-a5ca118ef4f5.png)
