### PR TITLE
Don't let form fields' text alignment be affected by a parent

### DIFF
--- a/src/lib/components/ui/MultipleSelectField/MultipleSelectField.scss
+++ b/src/lib/components/ui/MultipleSelectField/MultipleSelectField.scss
@@ -8,6 +8,7 @@
 
 // Foundation
 .root {
+  @include form-field();
   @include form-field-horizontal-neighbor();
 }
 

--- a/src/lib/components/ui/SelectField/SelectField.scss
+++ b/src/lib/components/ui/SelectField/SelectField.scss
@@ -8,6 +8,7 @@
 
 // Foundation
 .root {
+  @include form-field();
   @include form-field-horizontal-neighbor();
 }
 

--- a/src/lib/components/ui/TextArea/TextArea.scss
+++ b/src/lib/components/ui/TextArea/TextArea.scss
@@ -8,6 +8,7 @@
 
 // Foundation
 .root {
+  @include form-field();
   @include form-field-horizontal-neighbor();
 }
 

--- a/src/lib/components/ui/TextField/TextField.scss
+++ b/src/lib/components/ui/TextField/TextField.scss
@@ -8,6 +8,7 @@
 
 // Foundation
 .root {
+  @include form-field();
   @include form-field-horizontal-neighbor();
 }
 

--- a/src/lib/styles/tools/forms/_foundation.scss
+++ b/src/lib/styles/tools/forms/_foundation.scss
@@ -6,6 +6,7 @@
 // 5. Leave out space for Select Field caret.
 // 6. Align label to input baseline. Achieved with `padding-top` since `align-items: baseline`
 //    unfortunately doesn't work for blank text inputs in Safari.
+// 7. Don't let text alignment be affected by a parent.
 
 @import '../../settings/forms';
 @import '../../settings/forms-theme';
@@ -13,6 +14,10 @@
 @import '../../tools/offset';
 @import '../transitions';
 @import 'states';
+
+@mixin form-field() {
+  text-align: left; // 7.
+}
 
 @mixin form-field-label() {
   padding-top: calc(#{$form-field-border-width} + var(--rui-local-padding-vertical)); // 6.


### PR DESCRIPTION
The text alignment of form field labels could have been affected by a parent. This is now fixed.