### PR TITLE
BC: Make `List` RTL ready (#84)

### DIFF
--- a/src/demo/pages/DemoContainer.jsx
+++ b/src/demo/pages/DemoContainer.jsx
@@ -827,7 +827,7 @@ class DemoContainer extends React.Component {
             <Documentation
               name="Right-aligned list"
               component={(
-                <List align="right">
+                <List align="end">
                   <ListItem>
                     <Placeholder text="item 1" />
                   </ListItem>
@@ -843,7 +843,7 @@ class DemoContainer extends React.Component {
             <Documentation
               name="Right-aligned list with auto width"
               component={(
-                <List align="right" autoWidth>
+                <List align="end" autoWidth>
                   <ListItem>
                     <Placeholder text="item no. 1" />
                   </ListItem>

--- a/src/lib/components/layout/List/List.jsx
+++ b/src/lib/components/layout/List/List.jsx
@@ -15,10 +15,10 @@ const List = (props) => {
 
   let alignClass = '';
 
-  if (align === 'left') {
-    alignClass = styles.alignLeft;
-  } else if (align === 'right') {
-    alignClass = styles.alignRight;
+  if (align === 'start') {
+    alignClass = styles.alignStart;
+  } else if (align === 'end') {
+    alignClass = styles.alignEnd;
   }
 
   let autoWidthClass = '';
@@ -47,13 +47,13 @@ const List = (props) => {
 };
 
 List.defaultProps = {
-  align: 'left',
+  align: 'start',
   autoWidth: false,
   children: null,
 };
 
 List.propTypes = {
-  align: PropTypes.oneOf(['left', 'right']),
+  align: PropTypes.oneOf(['start', 'end']),
   autoWidth: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/src/lib/components/layout/List/List.scss
+++ b/src/lib/components/layout/List/List.scss
@@ -22,13 +22,22 @@
   }
 }
 
-.alignLeft {
+.alignStart {
   align-items: flex-start;
+  text-align: left;
 }
 
-.alignRight {
+.alignEnd {
   align-items: flex-end;
   text-align: right;
+}
+
+[dir="rtl"] .alignStart {
+  text-align: right;
+}
+
+[dir="rtl"] .alignEnd {
+  text-align: left;
 }
 
 .isAutoWidth .list {

--- a/src/lib/components/layout/List/__tests__/List.test.jsx
+++ b/src/lib/components/layout/List/__tests__/List.test.jsx
@@ -36,7 +36,7 @@ describe('rendering', () => {
 
   it('renders correctly with multiple children and all props', () => {
     const tree = shallow((
-      <List align="right" autoWidth>
+      <List align="end" autoWidth>
         <ListItem>content 1</ListItem>
         <ListItem>content 2</ListItem>
         <ListItem>content 3</ListItem>

--- a/src/lib/components/layout/List/__tests__/__snapshots__/List.test.jsx.snap
+++ b/src/lib/components/layout/List/__tests__/__snapshots__/List.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`rendering renders correctly with a single child 1`] = `
 >
   <ul
     className="list
-          alignLeft"
+          alignStart"
   >
     <ListItem>
       content
@@ -21,7 +21,7 @@ exports[`rendering renders correctly with multiple children 1`] = `
 >
   <ul
     className="list
-          alignLeft"
+          alignStart"
   >
     <ListItem>
       content 1
@@ -43,7 +43,7 @@ exports[`rendering renders correctly with multiple children and all props 1`] = 
 >
   <ul
     className="list
-          alignRight"
+          alignEnd"
   >
     <ListItem>
       content 1


### PR DESCRIPTION
The heading "Right-aligned List" doesn't make sense but 1) RTL readiness is now just an under-the-hood preparation, and 2) the demo will disappear soon anyway. The shift of mindset to the RTL-aware API is the more important thing here.

<img width="1106" alt="Snímek obrazovky 2020-09-03 v 12 04 36" src="https://user-images.githubusercontent.com/5614085/92102266-abdafe80-edde-11ea-8393-1ef3b242803d.png">

Closes #84.