### PR TITLE
Extend utilities

### DIFF
--- a/src/lib/components/ui/ScrollView/ScrollView.jsx
+++ b/src/lib/components/ui/ScrollView/ScrollView.jsx
@@ -212,13 +212,13 @@ export const ScrollView = (props) => {
         customStartShadowStyle,
         customEndShadowStyle,
       )}
-      {...(id && { id })}
+      id={id}
     >
       <div className={styles.viewport} ref={scrollViewViewportEl}>
         <div
           className={styles.content}
           ref={scrollViewContentEl}
-          {...(id && { id: `${id}__content` })}
+          id={id && `${id}__content`}
         >
           {children}
         </div>
@@ -236,7 +236,7 @@ export const ScrollView = (props) => {
               arrowsScrollStep,
             )}
             title={translations.previous}
-            {...(id && { id: `${id}__arrowPrevButton` })}
+            id={id && `${id}__arrowPrevButton`}
           >
             {customPrevArrow || (
               <span className={styles.arrowIcon} aria-hidden />
@@ -252,7 +252,7 @@ export const ScrollView = (props) => {
               arrowsScrollStep,
             )}
             title={translations.next}
-            {...(id && { id: `${id}__arrowNextButton` })}
+            id={id && `${id}__arrowNextButton`}
           >
             {customNextArrow || (
               <span className={styles.arrowIcon} aria-hidden />

--- a/src/lib/components/ui/Table/__tests__/Table.test.jsx
+++ b/src/lib/components/ui/Table/__tests__/Table.test.jsx
@@ -62,7 +62,7 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls changeHandler() on Close button click', () => {
+  it('calls changeHandler() on sorting button click', () => {
     const spy = sinon.spy();
     const component = mount((
       <Table

--- a/src/lib/styles/settings/_utilities.scss
+++ b/src/lib/styles/settings/_utilities.scss
@@ -7,7 +7,7 @@ $utilities: (
     responsive: true,
     property: display,
     class: d,
-    values: (block, flex, inline, inline-flex, none),
+    values: (block, flex, inline, inline-block, inline-flex, none),
   ),
   'align-items': (
     responsive: true,
@@ -19,7 +19,7 @@ $utilities: (
     responsive: true,
     property: justify-content,
     class: justify-content,
-    values: (start, end, center, space-between),
+    values: (start, flex-start, end, flex-end, center, space-between),
   ),
   'margin-top': (
     responsive: true,


### PR DESCRIPTION
I'm just adding a couple of new `display` utility classes because I was expecting them when I was writing the docs (#15) and they weren't there. I think that our future users could think the same.