### PR TITLE
Change default `Alert` stripe width to match other borders for a more generic look (#179)

### DIFF
--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -148,7 +148,7 @@
   --rui-alert-emphasis-font-weight: var(--rui-typography-font-weight-bold);
   --rui-alert-border-width: var(--rui-border-width);
   --rui-alert-border-radius: var(--rui-border-radius);
-  --rui-alert-stripe-width: var(--rui-spacing-2);
+  --rui-alert-stripe-width: var(--rui-border-width);
   --rui-alert-padding: var(--rui-spacing-3);
 
   // Alerts: type: success


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5614085/97763431-df4eb680-1b0b-11eb-8d70-b7d4670c2395.png)

Closes #179.