### PR TITLE
Extend `Grid` layout with responsive alignment options (#193)

### DIFF
--- a/src/lib/components/layout/Grid/Grid.jsx
+++ b/src/lib/components/layout/Grid/Grid.jsx
@@ -4,11 +4,15 @@ import { generateResponsiveCustomProperties } from './helpers/generateResponsive
 import styles from './Grid.scss';
 
 export const Grid = ({
+  alignContent,
+  alignItems,
   autoFlow,
   children,
   columnGap,
   columns,
   id,
+  justifyContent,
+  justifyItems,
   rowGap,
   rows,
   ...other
@@ -27,6 +31,10 @@ export const Grid = ({
         ...generateResponsiveCustomProperties(columnGap, 'column-gap'),
         ...generateResponsiveCustomProperties(rows, 'rows'),
         ...generateResponsiveCustomProperties(rowGap, 'row-gap'),
+        ...generateResponsiveCustomProperties(alignContent, 'align-content'),
+        ...generateResponsiveCustomProperties(alignItems, 'align-items'),
+        ...generateResponsiveCustomProperties(justifyContent, 'justify-content'),
+        ...generateResponsiveCustomProperties(justifyItems, 'justify-items'),
       }}
       {...other}
     >
@@ -39,16 +47,52 @@ export const Grid = ({
 /* eslint-disable sort-keys */
 
 Grid.defaultProps = {
+  alignContent: undefined,
+  alignItems: undefined,
+  autoFlow: undefined,
   children: null,
   columnGap: undefined,
   columns: undefined,
-  autoFlow: undefined,
   id: undefined,
+  justifyContent: undefined,
+  justifyItems: undefined,
   rowGap: undefined,
   rows: undefined,
 };
 
 Grid.propTypes = {
+  /**
+   * Content alignment. Accepts any valid value of `align-content` CSS property.
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content) for more.
+   */
+  alignContent: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.shape({
+      xs: PropTypes.string,
+      sm: PropTypes.string,
+      md: PropTypes.string,
+      lg: PropTypes.string,
+      xl: PropTypes.string,
+      xxl: PropTypes.string,
+      xxxl: PropTypes.string,
+    }),
+  ]),
+  /**
+   * Items alignment. Accepts any valid value of `align-items` CSS property.
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) for more.
+   */
+  alignItems: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.shape({
+      xs: PropTypes.string,
+      sm: PropTypes.string,
+      md: PropTypes.string,
+      lg: PropTypes.string,
+      xl: PropTypes.string,
+      xxl: PropTypes.string,
+      xxxl: PropTypes.string,
+    }),
+  ]),
   /**
    * Grid auto-flow algorithm to be used. Accepts any valid value of `grid-auto-flow` CSS property.
    * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow) for more.
@@ -94,6 +138,38 @@ Grid.propTypes = {
    * ID of the root HTML element.
    */
   id: PropTypes.string,
+  /**
+   * Content justification. Accepts any valid value of `justify-content` CSS property.
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) for more.
+   */
+  justifyContent: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.shape({
+      xs: PropTypes.string,
+      sm: PropTypes.string,
+      md: PropTypes.string,
+      lg: PropTypes.string,
+      xl: PropTypes.string,
+      xxl: PropTypes.string,
+      xxxl: PropTypes.string,
+    }),
+  ]),
+  /**
+   * Items justification. Accepts any valid value of `justify-items` CSS property.
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items) for more.
+   */
+  justifyItems: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.shape({
+      xs: PropTypes.string,
+      sm: PropTypes.string,
+      md: PropTypes.string,
+      lg: PropTypes.string,
+      xl: PropTypes.string,
+      xxl: PropTypes.string,
+      xxxl: PropTypes.string,
+    }),
+  ]),
   /**
    * Gap between rows. Accepts any valid value of `grid-row-gap` CSS property.
    * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) for more.

--- a/src/lib/components/layout/Grid/Grid.scss
+++ b/src/lib/components/layout/Grid/Grid.scss
@@ -31,6 +31,10 @@
     column-gap: var(--rui-grid-column-gap),
     rows: var(--rui-grid-rows),
     row-gap: var(--rui-grid-row-gap),
+    align-content: var(--rui-grid-align-content),
+    align-items: var(--rui-grid-align-items),
+    justify-content: var(--rui-grid-justify-content),
+    justify-items: var(--rui-grid-justify-items),
   );
 
   @include assign-responsive-custom-properties($_properties); // 1.
@@ -40,6 +44,10 @@
   grid-template-rows: var(--rui-local-rows); // 2.
   grid-gap: var(--rui-local-row-gap) var(--rui-local-column-gap); // 2.
   grid-auto-flow: var(--rui-local-auto-flow, var(--rui-grid-auto-flow)); // 3.
+  align-content: var(--rui-local-align-content, var(--rui-grid-align-content)); // 2.
+  align-items: var(--rui-local-align-items, var(--rui-grid-align-items)); // 2.
+  justify-content: var(--rui-local-justify-content, var(--rui-grid-justify-content)); // 2.
+  justify-items: var(--rui-local-justify-items, var(--rui-grid-justify-items)); // 2.
   margin-bottom: $layout-common-bottom-spacing;
 }
 

--- a/src/lib/components/layout/Grid/README.mdx
+++ b/src/lib/components/layout/Grid/README.mdx
@@ -48,9 +48,13 @@ See [API](#api) for all available options.
   [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns),
   [grid-template-rows](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows),
   [grid-column-gap](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap),
-  [grid-row-gap](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap), and
-  [grid-auto-flow](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow)
-  CSS properties in corresponding API options of the component.
+  [grid-row-gap](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap),
+  [grid-auto-flow](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow),
+  [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content),
+  [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items),
+  [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content),
+  [justify-items](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
+  and CSS properties in corresponding API options of the component.
 
 - To align your items in the grid, **simply wrap** them with the Grid
   component. Unlike other grid frameworks and UI libraries, **no additional
@@ -121,6 +125,26 @@ Both column and row gaps can be customized.
   <Grid columns="repeat(3, 1fr)" columnGap="0.75rem" rowGap="2rem">
     <Placeholder bordered>Grid item</Placeholder>
     <Placeholder bordered>Grid item</Placeholder>
+    <Placeholder bordered>Grid item</Placeholder>
+    <Placeholder bordered>Grid item</Placeholder>
+    <Placeholder bordered>Grid item</Placeholder>
+    <Placeholder bordered>Grid item</Placeholder>
+  </Grid>
+</Playground>
+
+## Alignment
+
+Individual items and the entire grid content can be aligned and along both axes.
+
+<Playground>
+  <Grid
+    columns="repeat(3, 10em)"
+    alignItems="center"
+    justifyItems="center"
+    justifyContent="center"
+  >
+    <Placeholder bordered>Grid item</Placeholder>
+    <Placeholder bordered>Grid item<br /> with two lines</Placeholder>
     <Placeholder bordered>Grid item</Placeholder>
     <Placeholder bordered>Grid item</Placeholder>
     <Placeholder bordered>Grid item</Placeholder>

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -543,6 +543,10 @@
   --rui-grid-rows: auto;
   --rui-grid-row-gap: var(--rui-spacing-4);
   --rui-grid-auto-flow: initial;
+  --rui-grid-align-content: initial;
+  --rui-grid-align-items: initial;
+  --rui-grid-justify-content: initial;
+  --rui-grid-justify-items: initial;
 
   //
   // Modal


### PR DESCRIPTION
It's necessary to be able to restore original behaviour in our project.

![image](https://user-images.githubusercontent.com/5614085/98864930-e7431a80-246a-11eb-883e-dcb0351dd399.png)
