### PR TITLE
Make code font family and font size customizable

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -63,6 +63,12 @@ export default {
         },
       },
     },
+    editor: {
+      fontSize: 1,
+    },
+    fonts: {
+      monospace: 'var(--rui-code-font-family)',
+    },
     prism: {
       dark: vsDarkTheme,
       light: vsDarkTheme,
@@ -112,6 +118,9 @@ export default {
         },
         code: {
           bg: 'rgba(0, 0, 0, 0.05)',
+        },
+        'code, pre': {
+          fontSize: '80%', // Adjust code font size to work better with 20px body text size.
         },
         h1: {
           fontFamily: defaultFontFamily,

--- a/src/gatsby-theme-docz/index.css
+++ b/src/gatsby-theme-docz/index.css
@@ -1,0 +1,1 @@
+/* Empty file means don't load any external web fonts defined in gatsby-theme-docz. */

--- a/src/gatsby-theme-docz/theme/prism/dark.js
+++ b/src/gatsby-theme-docz/theme/prism/dark.js
@@ -1,0 +1,2 @@
+// We want the same appearance in both light and dark mode.
+export { default } from './light';

--- a/src/gatsby-theme-docz/theme/prism/light.js
+++ b/src/gatsby-theme-docz/theme/prism/light.js
@@ -1,0 +1,77 @@
+export default {
+  plain: {
+    fontFamily: 'var(--rui-code-font-family)',
+    fontSize: '1rem',
+    lineHeight: 1.45,
+    color: '#393A34',
+    backgroundColor: '#f6f8fa',
+  },
+  styles: [
+    {
+      types: ['comment', 'prolog', 'doctype', 'cdata'],
+      style: {
+        color: '#999988',
+        fontStyle: 'italic',
+      },
+    },
+    {
+      types: ['namespace'],
+      style: {
+        opacity: 0.7,
+      },
+    },
+    {
+      types: ['string', 'attr-value'],
+      style: {
+        color: '#e3116c',
+      },
+    },
+    {
+      types: ['punctuation', 'operator'],
+      style: {
+        color: '#393A34',
+      },
+    },
+    {
+      types: [
+        'entity',
+        'url',
+        'symbol',
+        'number',
+        'boolean',
+        'variable',
+        'constant',
+        'property',
+        'regex',
+        'inserted',
+      ],
+      style: {
+        color: '#36acaa',
+      },
+    },
+    {
+      types: ['atrule', 'keyword', 'attr-name', 'selector'],
+      style: {
+        color: '#00a4db',
+      },
+    },
+    {
+      types: ['function', 'deleted', 'tag'],
+      style: {
+        color: '#d73a49',
+      },
+    },
+    {
+      types: ['function-variable'],
+      style: {
+        color: '#6f42c1',
+      },
+    },
+    {
+      types: ['tag', 'selector', 'keyword'],
+      style: {
+        color: '#00009f',
+      },
+    },
+  ],
+}

--- a/src/lib/styles/elements/_code.scss
+++ b/src/lib/styles/elements/_code.scss
@@ -1,4 +1,11 @@
+@use '../theme/code';
 @use '../theme/colors';
+
+code,
+pre {
+  font-size: code.$font-size;
+  font-family: code.$font-family;
+}
 
 code {
   padding: 0.15em 0.5em;

--- a/src/lib/styles/theme/_code.scss
+++ b/src/lib/styles/theme/_code.scss
@@ -1,0 +1,2 @@
+$font-family: var(--rui-code-font-family);
+$font-size: var(--rui-code-font-size);

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -118,6 +118,10 @@
   // Lists
   --rui-list-unordered-style: square;
 
+  // Code
+  --rui-code-font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --rui-code-font-size: 85%;
+
   //
   // Typography
   // ==========


### PR DESCRIPTION
Code font family and font size are now customizable.

These settings are also reflected in docs where the code block appearance has been unified and slightly tweaked to work better with bigger font size of the docs.