### PR TITLE
Collapse Playground code by default

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -73,6 +73,7 @@ export default {
       dark: vsDarkTheme,
       light: vsDarkTheme,
     },
+    showPlaygroundEditor: false,
     styles: {
       Container: {
         '& > table': {


### PR DESCRIPTION
Live code examples are now collapsed by default to make docs easier to scan:

![image](https://user-images.githubusercontent.com/5614085/106800790-357a4b00-6661-11eb-9c4e-9026b328a440.png)
