### PR TITLE
Get rid of unwanted spacing of inline elements placed in `Toolbar`

### DIFF
--- a/src/lib/components/layout/Toolbar/Toolbar.scss
+++ b/src/lib/components/layout/Toolbar/Toolbar.scss
@@ -1,3 +1,5 @@
+// 1. Get rid of unwanted spacing of inline elements by invocation of flex layout.
+
 @use 'theme';
 
 .toolbar,
@@ -11,7 +13,9 @@
 }
 
 .item {
+  display: flex; // 1.
   flex: none;
+  flex-direction: column; // 1.
   margin: theme.$spacing;
 }
 


### PR DESCRIPTION
The problem:

![image](https://user-images.githubusercontent.com/5614085/109347977-37a48380-7874-11eb-8393-3ab4c3d901dd.png)

The fix (that 1px space comes from calculation rounding in the checkbox itself):

![image](https://user-images.githubusercontent.com/5614085/109348081-59056f80-7874-11eb-8918-04317e58657f.png)
