### PR TITLE
Remove bottom margin from last-child elements (#180)

### DIFF
--- a/src/docs/foundation/spacing.mdx
+++ b/src/docs/foundation/spacing.mdx
@@ -24,3 +24,45 @@ help you keep your UI consistent.
 \* For the sake of brevity, usage in HTML only illustrates the top margin
 property. See [Spacing helpers](/css-helpers/spacing) for the full list of
 options.
+
+## Shared Spacings
+
+Commonly reused spacings. Bottom spacing is applied unless the element in
+question is a last child of its parent.
+
+| Category | Usage in CSS                    | Usage in SCSS              | Default value     | Shared by              |
+|----------|---------------------------------|----------------------------|-------------------|------------------------|
+| default  | `--rui-spacing-bottom-default`  | `spacing.bottom()`         | `--rui-spacing-5` | Paragraphs, lists etc. |
+| headings | `--rui-spacing-bottom-headings` | `spacing.bottom(headings)` | `--rui-spacing-5` | Heading elements       |
+| layouts  | `--rui-spacing-bottom-layouts`  | `spacing.bottom(layouts)`  | `--rui-spacing-5` | Layout components      |
+
+### Note on Live Playgrounds
+
+For demonstration purposes, all elements that are direct descendants of live
+playgrounds in these docs are given a standard margin on all sides which
+suppresses default spacing behavior described above:
+
+```jsx
+<Playground>
+  <p>This paragraph will have standard playground margin an all sides.</p>
+  <p>This paragraph will have it too.</p>
+</Playground>
+```
+
+Once wrapped in a `div`, all elements and components remain unaffected and have
+exactly the same margins as they would have in a real-world React UI project:
+
+```jsx
+<Playground>
+  <div>
+    <p>
+      This paragraph will have bottom margin of
+      <code>--rui-spacing-bottom-default</code>.
+    </p>
+    <p>
+      This paragraph is a last child of its parent and thus will have no bottom
+      margin.
+    </p>
+  </div>
+</Playground>
+```

--- a/src/lib/components/layout/CTA/CTA.scss
+++ b/src/lib/components/layout/CTA/CTA.scss
@@ -6,6 +6,8 @@ $_spacing: spacing.of(1);
 $_column-gap: spacing.of(3);
 
 .root {
+  @include spacing.bottom(layouts, $compensation: $_spacing);
+
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/src/lib/components/layout/FormLayout/FormLayout.scss
+++ b/src/lib/components/layout/FormLayout/FormLayout.scss
@@ -14,14 +14,14 @@
 //    https://github.com/react-ui-org/react-ui/issues/232
 
 @use '../../../styles/settings/forms';
-@use '../../../styles/settings/layouts';
 @use '../../../styles/tools/breakpoint';
+@use '../../../styles/tools/spacing';
 @use 'theme';
 
 .root {
   --rui-local-field-width: 1fr;
 
-  margin-bottom: layouts.$common-bottom-spacing;
+  @include spacing.bottom(layouts);
 }
 
 .rootFieldLayoutVertical,

--- a/src/lib/components/layout/FormLayout/README.mdx
+++ b/src/lib/components/layout/FormLayout/README.mdx
@@ -143,52 +143,50 @@ Try to resize the playground to see how individual options work.
     const [customLabelWidth, setCustomLabelWidth] = React.useState('20em');
     return (
       <div>
-        <div className="mb-6">
-          <Toolbar align="baseline">
+        <Toolbar align="baseline">
+          <ToolbarItem>
+            <span id="label-width-options-label">Label width:</span>
+          </ToolbarItem>
+          <ToolbarItem>
+            <ButtonGroup aria-labelledby="#label-width-options-label">
+              <Button
+                label="default"
+                clickHandler={() => setLabelWidth('default')}
+                variant={labelWidth === 'default' ? 'dark' : 'primary'}
+              />
+              <Button
+                label="auto"
+                clickHandler={() => setLabelWidth('auto')}
+                variant={labelWidth === 'auto' ? 'dark' : 'primary'}
+              />
+              <Button
+                label="limited"
+                clickHandler={() => setLabelWidth('limited')}
+                variant={labelWidth === 'limited' ? 'dark' : 'primary'}
+              />
+              <Button
+                label="custom"
+                clickHandler={() => setLabelWidth('custom')}
+                variant={labelWidth === 'custom' ? 'dark' : 'primary'}
+              />
+            </ButtonGroup>
+          </ToolbarItem>
+          {labelWidth === 'custom' && (
             <ToolbarItem>
-              <span id="label-width-options-label">Label width:</span>
+              <TextField
+                changeHandler={(e) => (
+                  setCustomLabelWidth(e.target.value)
+                )}
+                id="form-layout-custom-label-width"
+                inputSize={5}
+                isLabelVisible={false}
+                label="Custom label width"
+                layout="horizontal"
+                value={customLabelWidth}
+              />
             </ToolbarItem>
-            <ToolbarItem>
-              <ButtonGroup aria-labelledby="#label-width-options-label">
-                <Button
-                  label="default"
-                  clickHandler={() => setLabelWidth('default')}
-                  variant={labelWidth === 'default' ? 'dark' : 'primary'}
-                />
-                <Button
-                  label="auto"
-                  clickHandler={() => setLabelWidth('auto')}
-                  variant={labelWidth === 'auto' ? 'dark' : 'primary'}
-                />
-                <Button
-                  label="limited"
-                  clickHandler={() => setLabelWidth('limited')}
-                  variant={labelWidth === 'limited' ? 'dark' : 'primary'}
-                />
-                <Button
-                  label="custom"
-                  clickHandler={() => setLabelWidth('custom')}
-                  variant={labelWidth === 'custom' ? 'dark' : 'primary'}
-                />
-              </ButtonGroup>
-            </ToolbarItem>
-            {labelWidth === 'custom' && (
-              <ToolbarItem>
-                <TextField
-                  changeHandler={(e) => (
-                    setCustomLabelWidth(e.target.value)
-                  )}
-                  id="form-layout-custom-label-width"
-                  inputSize={5}
-                  isLabelVisible={false}
-                  label="Custom label width"
-                  layout="horizontal"
-                  value={customLabelWidth}
-                />
-              </ToolbarItem>
-            )}
-          </Toolbar>
-        </div>
+          )}
+        </Toolbar>
         <FormLayout
           fieldLayout="horizontal"
           labelWidth={labelWidth === 'custom' ? customLabelWidth : labelWidth}
@@ -289,21 +287,23 @@ This is a demo of all components supported by FormLayout.
       },
     ];
     return (
-      <>
-        <div className="mb-6">
-          <ButtonGroup>
-            <Button
-              clickHandler={() => setFieldLayout('vertical')}
-              label="Vertical layout"
-              variant={fieldLayout === 'vertical' ? 'dark' : 'primary'}
-            />
-            <Button
-              clickHandler={() => setFieldLayout('horizontal')}
-              label="Horizontal layout"
-              variant={fieldLayout === 'horizontal' ? 'dark' : 'primary'}
-            />
-          </ButtonGroup>
-        </div>
+      <div>
+        <Toolbar>
+          <ToolbarItem>
+            <ButtonGroup>
+              <Button
+                clickHandler={() => setFieldLayout('vertical')}
+                label="Vertical layout"
+                variant={fieldLayout === 'vertical' ? 'dark' : 'primary'}
+              />
+              <Button
+                clickHandler={() => setFieldLayout('horizontal')}
+                label="Horizontal layout"
+                variant={fieldLayout === 'horizontal' ? 'dark' : 'primary'}
+              />
+            </ButtonGroup>
+          </ToolbarItem>
+        </Toolbar>
         <FormLayout fieldLayout={fieldLayout} labelWidth="auto">
           <>
             <TextField
@@ -394,7 +394,7 @@ This is a demo of all components supported by FormLayout.
             value={fruit}
           />
         </FormLayout>
-      </>
+      </div>
     )
   }}
 </Playground>

--- a/src/lib/components/layout/Grid/Grid.scss
+++ b/src/lib/components/layout/Grid/Grid.scss
@@ -22,7 +22,7 @@
 //
 // 3. Any valid auto-flow algorithm can be used. It's applied globally for all breakpoints.
 
-@use '../../../styles/settings/layouts';
+@use '../../../styles/tools/spacing';
 @use 'tools';
 
 .root {
@@ -38,6 +38,7 @@
   );
 
   @include tools.assign-responsive-custom-properties($properties); // 1.
+  @include spacing.bottom(layouts);
 
   display: grid;
   grid-template-columns: var(--rui-local-columns); // 2.
@@ -48,7 +49,6 @@
   align-items: var(--rui-local-align-items, var(--rui-grid-align-items)); // 2.
   justify-content: var(--rui-local-justify-content, var(--rui-grid-justify-content)); // 2.
   justify-items: var(--rui-local-justify-items, var(--rui-grid-justify-items)); // 2.
-  margin-bottom: layouts.$common-bottom-spacing;
 }
 
 .span {

--- a/src/lib/components/layout/List/List.scss
+++ b/src/lib/components/layout/List/List.scss
@@ -1,8 +1,7 @@
-@use '../../../styles/settings/layouts';
 @use '../../../styles/tools/spacing';
 
 .root {
-  margin-bottom: layouts.$common-bottom-spacing;
+  @include spacing.bottom(layouts);
 }
 
 .list {

--- a/src/lib/components/layout/Media/Media.scss
+++ b/src/lib/components/layout/Media/Media.scss
@@ -1,10 +1,10 @@
-@use '../../../styles/settings/layouts';
 @use '../../../styles/tools/spacing';
 
 .media {
+  @include spacing.bottom(layouts);
+
   display: flex;
   align-items: flex-start;
-  margin-bottom: layouts.$common-bottom-spacing;
 }
 
 .object {

--- a/src/lib/components/layout/Toolbar/README.mdx
+++ b/src/lib/components/layout/Toolbar/README.mdx
@@ -75,56 +75,66 @@ of `right`.
     const [justification, setJustification] = React.useState('start');
     return (
       <div>
-        <div className="mb-2">
-          <span id="alignment-label" className="mr-3">Alignment:</span>
-          <ButtonGroup aria-labelledby="#alignment-label">
-            <Button
-              label="top"
-              clickHandler={() => setAlignment('top')}
-              variant={alignment === 'top' ? 'dark' : 'primary'}
-            />
-            <Button
-              label="middle"
-              clickHandler={() => setAlignment('middle')}
-              variant={alignment === 'middle' ? 'dark' : 'primary'}
-            />
-            <Button
-              label="bottom"
-              clickHandler={() => setAlignment('bottom')}
-              variant={alignment === 'bottom' ? 'dark' : 'primary'}
-            />
-            <Button
-              label="baseline"
-              clickHandler={() => setAlignment('baseline')}
-              variant={alignment === 'baseline' ? 'dark' : 'primary'}
-            />
-          </ButtonGroup>
-        </div>
-        <div className="mb-5">
-          <span id="justification-label" className="mr-3">Justification:</span>
-          <ButtonGroup aria-labelledby="#justification-label">
-            <Button
-              label="start"
-              clickHandler={() => setJustification('start')}
-              variant={justification === 'start' ? 'dark' : 'primary'}
-            />
-            <Button
-              label="center"
-              clickHandler={() => setJustification('center')}
-              variant={justification === 'center' ? 'dark' : 'primary'}
-            />
-            <Button
-              label="end"
-              clickHandler={() => setJustification('end')}
-              variant={justification === 'end' ? 'dark' : 'primary'}
-            />
-            <Button
-              label="space-between"
-              clickHandler={() => setJustification('space-between')}
-              variant={justification === 'space-between' ? 'dark' : 'primary'}
-            />
-          </ButtonGroup>
-        </div>
+        <Toolbar>
+          <ToolbarGroup align="baseline">
+            <ToolbarItem>
+              <span id="alignment-label">Alignment:</span>
+            </ToolbarItem>
+            <ToolbarItem>
+              <ButtonGroup aria-labelledby="#alignment-label">
+                <Button
+                  label="top"
+                  clickHandler={() => setAlignment('top')}
+                  variant={alignment === 'top' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="middle"
+                  clickHandler={() => setAlignment('middle')}
+                  variant={alignment === 'middle' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="bottom"
+                  clickHandler={() => setAlignment('bottom')}
+                  variant={alignment === 'bottom' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="baseline"
+                  clickHandler={() => setAlignment('baseline')}
+                  variant={alignment === 'baseline' ? 'dark' : 'primary'}
+                />
+              </ButtonGroup>
+            </ToolbarItem>
+          </ToolbarGroup>
+          <ToolbarGroup align="baseline">
+            <ToolbarItem>
+              <span id="justification-label">Justification:</span>
+            </ToolbarItem>
+            <ToolbarItem>
+              <ButtonGroup aria-labelledby="#justification-label">
+                <Button
+                  label="start"
+                  clickHandler={() => setJustification('start')}
+                  variant={justification === 'start' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="center"
+                  clickHandler={() => setJustification('center')}
+                  variant={justification === 'center' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="end"
+                  clickHandler={() => setJustification('end')}
+                  variant={justification === 'end' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="space-between"
+                  clickHandler={() => setJustification('space-between')}
+                  variant={justification === 'space-between' ? 'dark' : 'primary'}
+                />
+              </ButtonGroup>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </Toolbar>
         <Toolbar align={alignment} justify={justification}>
           <ToolbarItem>
             <Placeholder bordered>First item</Placeholder>
@@ -187,20 +197,24 @@ toolbar groups, or on the entire toolbar.
     const [isToolbarDense, setIsToolbarDense] = React.useState(false);
     return (
       <div>
-        <div className="mb-5">
-          <CheckboxField
-            id="is-group-dense"
-            label="Dense ToolbarGroup"
-            changeHandler={(e) => setIsGroupDense(e.target.checked)}
-            checked={isGroupDense}
-          />
-          <CheckboxField
-            id="is-toolbar-dense"
-            label="Dense Toolbar"
-            changeHandler={(e) => setIsToolbarDense(e.target.checked)}
-            checked={isToolbarDense}
-          />
-        </div>
+        <Toolbar>
+          <ToolbarItem>
+            <CheckboxField
+              id="is-group-dense"
+              label="Dense ToolbarGroup"
+              changeHandler={(e) => setIsGroupDense(e.target.checked)}
+              checked={isGroupDense}
+            />
+          </ToolbarItem>
+          <ToolbarItem>
+            <CheckboxField
+              id="is-toolbar-dense"
+              label="Dense Toolbar"
+              changeHandler={(e) => setIsToolbarDense(e.target.checked)}
+              checked={isToolbarDense}
+            />
+          </ToolbarItem>
+        </Toolbar>
         <Toolbar dense={isToolbarDense}>
           <ToolbarGroup dense={isGroupDense}>
             <ToolbarItem>

--- a/src/lib/components/layout/Toolbar/Toolbar.scss
+++ b/src/lib/components/layout/Toolbar/Toolbar.scss
@@ -1,5 +1,6 @@
 // 1. Get rid of unwanted spacing of inline elements by invocation of flex layout.
 
+@use '../../../styles/tools/spacing';
 @use 'theme';
 
 .toolbar,
@@ -9,6 +10,8 @@
 }
 
 .toolbar {
+  @include spacing.bottom(layouts, $compensation: theme.$spacing);
+
   margin: calc(-1 * #{theme.$spacing});
 }
 
@@ -69,6 +72,10 @@
 
 .isDense > .isDense {
   margin: 0;
+}
+
+.toolbar.isDense {
+  @include spacing.bottom(layouts, $compensation: theme.$spacing-dense);
 }
 
 .toolbar:not(.isDense) > .isDense,

--- a/src/lib/components/ui/Modal/Modal.scss
+++ b/src/lib/components/ui/Modal/Modal.scss
@@ -36,8 +36,11 @@
 }
 
 .headTitle {
-  margin-bottom: 0;
   font-size: settings.$head-title-font-size;
+
+  &:not(:last-child) {
+    margin-bottom: 0;
+  }
 }
 
 .close {
@@ -60,7 +63,7 @@
 }
 
 .content {
-  padding: settings.$padding-y settings.$padding-x;
+  padding: settings.$padding-y settings.$padding-x settings.$content-padding-bottom;
 }
 
 .footer {

--- a/src/lib/components/ui/Modal/_settings.scss
+++ b/src/lib/components/ui/Modal/_settings.scss
@@ -5,6 +5,7 @@
 
 $padding-x: spacing.of(5);
 $padding-y: spacing.of(3);
+$content-padding-bottom: spacing.of(6);
 $border-radius: borders.$radius;
 $head-title-font-size: map-get(typography.$size-values, 1);
 $z-index: z-indexes.$modal;

--- a/src/lib/components/ui/ScrollView/README.mdx
+++ b/src/lib/components/ui/ScrollView/README.mdx
@@ -15,6 +15,8 @@ import {
 import { Placeholder } from '../../../../docs/_components/Placeholder/Placeholder'
 import Button from '../Button'
 import Radio from '../Radio'
+import { Toolbar } from '../../layout/Toolbar/Toolbar'
+import { ToolbarItem } from '../../layout/Toolbar/ToolbarItem'
 import {
   ScrollViewWithContext as ScrollView,
   ScrollView as ParsableScrollView,
@@ -213,49 +215,55 @@ property defined because it detects changes of these keys.
       generateRandomString(),
     );
     return (
-      <>
-        <div className="mb-5">
-          <Radio
-            changeHandler={(e) => setDirection(e.target.value)}
-            options={[
-              {
-                label: 'Vertical',
-                value: 'vertical',
-              },
-              {
-                label: 'Horizontal',
-                value: 'horizontal',
-              },
-            ]}
-            id="scroll-view-direction"
-            label="Direction:"
-            value={direction}
-          />
-          <Radio
-            changeHandler={(e) => setAutoScroll(e.target.value)}
-            options={[
-              {
-                label: 'Always',
-                value: 'always',
-              },
-              {
-                label: 'When end is detected',
-                value: 'detectEnd',
-              },
-            ]}
-            id="scroll-view-autoscroll"
-            label="Autoscroll:"
-            value={autoScroll}
-          />
-          <Button
-            label="Add text"
-            clickHandler={
-              () => setScrollViewContent(
-                `${scrollViewContent} ${generateRandomString()}`,
-              )
-            }
-          />
-        </div>
+      <div>
+        <Toolbar>
+          <ToolbarItem>
+            <Radio
+              changeHandler={(e) => setDirection(e.target.value)}
+              options={[
+                {
+                  label: 'Vertical',
+                  value: 'vertical',
+                },
+                {
+                  label: 'Horizontal',
+                  value: 'horizontal',
+                },
+              ]}
+              id="scroll-view-direction"
+              label="Direction:"
+              value={direction}
+            />
+          </ToolbarItem>
+          <ToolbarItem>
+            <Radio
+              changeHandler={(e) => setAutoScroll(e.target.value)}
+              options={[
+                {
+                  label: 'Always',
+                  value: 'always',
+                },
+                {
+                  label: 'When end is detected',
+                  value: 'detectEnd',
+                },
+              ]}
+              id="scroll-view-autoscroll"
+              label="Autoscroll:"
+              value={autoScroll}
+            />
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button
+              label="Add text"
+              clickHandler={
+                () => setScrollViewContent(
+                  `${scrollViewContent} ${generateRandomString()}`,
+                )
+              }
+            />
+          </ToolbarItem>
+        </Toolbar>
         <Placeholder height={direction === 'vertical' ? '200px' : 'auto'}>
           <ScrollView arrows autoScroll={autoScroll} direction={direction}>
             <div
@@ -268,7 +276,7 @@ property defined because it detects changes of these keys.
             </div>
           </ScrollView>
         </Placeholder>
-      </>
+      </div>
     );
   }}
 </Playground>

--- a/src/lib/styles/generic/_shared.scss
+++ b/src/lib/styles/generic/_shared.scss
@@ -2,12 +2,6 @@
 
 // Always declare margins in the same direction.
 address,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
 blockquote,
 p,
 pre,
@@ -18,5 +12,14 @@ figure,
 hr,
 table,
 fieldset {
-  margin-bottom: spacing.of(5);
+  @include spacing.bottom();
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @include spacing.bottom(headings);
 }

--- a/src/lib/styles/settings/_layouts.scss
+++ b/src/lib/styles/settings/_layouts.scss
@@ -1,3 +1,0 @@
-@use '../tools/spacing';
-
-$common-bottom-spacing: spacing.of(4);

--- a/src/lib/styles/theme/_spacing.scss
+++ b/src/lib/styles/theme/_spacing.scss
@@ -8,3 +8,9 @@ $values: (
   6: var(--rui-spacing-6),
   7: var(--rui-spacing-7),
 );
+
+$bottom: (
+  default: var(--rui-spacing-bottom-default),
+  headings: var(--rui-spacing-bottom-headings),
+  layouts: var(--rui-spacing-bottom-layouts),
+);

--- a/src/lib/styles/tools/_spacing.scss
+++ b/src/lib/styles/tools/_spacing.scss
@@ -11,3 +11,20 @@
     }
   }
 }
+
+@mixin bottom($category: default, $compensation: null) {
+  @if (not map-has-key(spacing.$bottom, $category)) {
+    @error "Invalid spacing category specified! #{$category} doesn't exist. "
+      + "Choose one of #{map-keys(spacing.$bottom)}.";
+  }
+
+  &:not(:last-child) {
+    @if ($compensation != null) {
+      margin-bottom: calc(#{map-get(spacing.$bottom, $category)} - #{$compensation});
+    }
+
+    @else {
+      margin-bottom: map-get(spacing.$bottom, $category);
+    }
+  }
+}

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -113,6 +113,11 @@
   --rui-tap-target-size: 10mm;
   --rui-focus-box-shadow: 0 0 0 0.2em var(--rui-color-active-focus);
 
+  // Bottom spacings
+  --rui-spacing-bottom-default: var(--rui-spacing-5);
+  --rui-spacing-bottom-headings: var(--rui-spacing-5);
+  --rui-spacing-bottom-layouts: var(--rui-spacing-5);
+
   //
   // Elements
   // ========


### PR DESCRIPTION
Separate shared bottom spacings into categories with configurable values.

New theming options:

- `--rui-spacing-bottom-default`
- `--rui-spacing-bottom-headings`
- `--rui-spacing-bottom-layouts`

![image](https://user-images.githubusercontent.com/5614085/113182897-b4e85d00-9253-11eb-94c4-c3f43c10ef30.png)

Closes #180.