### PR TITLE
Use unitless line height to take advantage of inheritance

### DIFF
--- a/src/lib/styles/tools/form-fields/_box-field-layout.scss
+++ b/src/lib/styles/tools/form-fields/_box-field-layout.scss
@@ -87,7 +87,7 @@
       @if ($has-min-tap-target) {
         padding-top:
           calc(
-            (#{theme.$check-tap-target-size} - #{typography.$line-height-base})
+            (#{theme.$check-tap-target-size} - 1rem * #{typography.$line-height-base})
             / 2
           ); // 10.
       }

--- a/src/lib/styles/tools/form-fields/_inline-field-elements.scss
+++ b/src/lib/styles/tools/form-fields/_inline-field-elements.scss
@@ -17,7 +17,7 @@
 
   width: theme.$check-input-size;
   height: theme.$check-input-size;
-  margin-top: calc((#{typography.$line-height-base} - #{theme.$check-input-size}) / 2);
+  margin-top: calc((1rem * #{typography.$line-height-base} - #{theme.$check-input-size}) / 2);
   border: theme.$check-input-border-width solid var(--rui-local-border-color);
   background-position: center;
   background-size: contain;
@@ -74,7 +74,7 @@
   @include accessibility.min-tap-target($size: theme.$check-tap-target-size, $center: false);
 
   min-height: theme.$check-tap-target-size;
-  padding-top: calc((#{theme.$check-tap-target-size} - #{typography.$line-height-base}) / 2);
+  padding-top: calc((#{theme.$check-tap-target-size} - 1rem * #{typography.$line-height-base}) / 2);
 
   &::before {
     top: 0;
@@ -93,7 +93,7 @@
       padding-top: 0;
 
       &::before {
-        top: calc((#{typography.$line-height-base} - #{theme.$check-tap-target-size}) / 2);
+        top: calc((#{typography.$line-height-base} - 1rem * #{theme.$check-tap-target-size}) / 2);
       }
     }
   }

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -147,7 +147,7 @@
   --rui-typography-font-weight-regular: 400;
   --rui-typography-font-weight-medium: 500;
   --rui-typography-font-weight-bold: 700;
-  --rui-typography-line-height-base: 1.5rem;
+  --rui-typography-line-height-base: 1.5;
   --rui-typography-size-smaller: 0.75rem;
   --rui-typography-size-small: 0.889rem;
   --rui-typography-size-0: 1rem;


### PR DESCRIPTION
⚠️ Breaking change, you may need to multiply your calculations by `1rem`.