### PR TITLE
Extend `FormLayoutCustomField` options to improve accessibility and design consistency (#174)

### DIFF
--- a/src/docs/customize/theming/forms.mdx
+++ b/src/docs/customize/theming/forms.mdx
@@ -49,7 +49,7 @@ Options for fields that support horizontal layout.
 | `--rui-form-field-horizontal-label-text-align`       | Text alignment of labels in horizontal layout                |
 | `--rui-form-field-horizontal-label-min-width`        | Minimum width of labels in horizontal layout                 |
 | `--rui-form-field-horizontal-label-width`            | Default width of labels in horizontal layout                 |
-| `--rui-form-field-horizontal-label-padding-top`      | Top padding to tweak vertical alignment of labels            |
+| `--rui-form-field-horizontal-label-padding-y`        | Top and bottom padding to tweak vertical alignment of labels |
 | `--rui-form-field-horizontal-label-vertical-alignment` | Vertical box alignment of labels in horizontal layout      |
 | `--rui-form-field-horizontal-field-vertical-alignment` | Vertical box alignment of fields in horizontal layout      |
 | `--rui-form-field-horizontal-full-width-label-width` | Default width of labels in full-width horizontal layout      |

--- a/src/lib/components/layout/FormLayout/FormLayoutCustomField.jsx
+++ b/src/lib/components/layout/FormLayout/FormLayoutCustomField.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import getRootSizeClassName from '../../../helpers/getRootSizeClassName';
+import getRootValidationStateClassName from '../../../helpers/getRootValidationStateClassName';
 import { withProviderContext } from '../../../provider';
 import styles from './FormLayoutCustomField.scss';
 
@@ -7,40 +9,76 @@ export const FormLayoutCustomField = ({
   children,
   fullWidth,
   id,
+  disabled,
+  innerFieldSize,
   label,
+  labelForId,
   layout,
-}) => (
-  <div
-    id={id}
-    className={`
-      ${styles.root}
-      ${fullWidth ? styles.isRootFullWidth : ''}
-      ${layout === 'vertical' ? styles.rootLayoutVertical : styles.rootLayoutHorizontal}
-    `.trim()}
-  >
-    {label && (
-      <div
-        id={id && `${id}__label`}
-        className={styles.label}
-      >
-        {label}
-      </div>
-    )}
+  required,
+  validationState,
+}) => {
+  const renderLabel = () => {
+    if (labelForId && label) {
+      return (
+        <label
+          htmlFor={labelForId}
+          id={id && `${id}__label`}
+          className={styles.label}
+        >
+          {label}
+        </label>
+      );
+    }
+
+    if (label) {
+      return (
+        <div
+          id={id && `${id}__label`}
+          className={styles.label}
+        >
+          {label}
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
     <div
-      id={id && `${id}__field`}
-      className={styles.field}
+      id={id}
+      className={[
+        styles.root,
+        fullWidth ? styles.isRootFullWidth : '',
+        layout === 'vertical' ? styles.rootLayoutVertical : styles.rootLayoutHorizontal,
+        disabled ? styles.isRootDisabled : '',
+        required ? styles.isRootRequired : '',
+        getRootSizeClassName(innerFieldSize, styles),
+        getRootValidationStateClassName(validationState, styles),
+      ].join(' ')}
     >
-      {children}
+      {renderLabel()}
+      <div
+        id={id && `${id}__field`}
+        className={styles.field}
+      >
+        {children}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 FormLayoutCustomField.defaultProps = {
   children: null,
+  disabled: false,
   fullWidth: false,
   id: undefined,
+  innerFieldSize: null,
   label: null,
+  labelForId: undefined,
   layout: 'vertical',
+  required: false,
+  validationState: null,
 };
 
 FormLayoutCustomField.propTypes = {
@@ -48,6 +86,10 @@ FormLayoutCustomField.propTypes = {
    * Custom HTML or React component(s).
    */
   children: PropTypes.node,
+  /**
+   * If `true`, label will be shown as disabled.
+   */
+  disabled: PropTypes.bool,
   /**
    * If `true`, the field will span the full width of its parent.
    */
@@ -57,13 +99,29 @@ FormLayoutCustomField.propTypes = {
    */
   id: PropTypes.string,
   /**
+   * Size of contained form field used to properly align label.
+   */
+  innerFieldSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /**
    * Optional label of the field.
    */
   label: PropTypes.string,
   /**
+   * Optional ID of labelled field to keep accessibility features.
+   */
+  labelForId: PropTypes.string,
+  /**
    * Layout of the field, controlled by parent FormLayout.
    */
   layout: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
+   * If `true`, label will be styled as required.
+   */
+  required: PropTypes.bool,
+  /**
+   * Alter the field to provide feedback based on validation result.
+   */
+  validationState: PropTypes.oneOf(['invalid', 'valid', 'warning']),
 };
 
 export const FormLayoutCustomFieldWithContext = withProviderContext(FormLayoutCustomField, 'FormLayoutCustomField');

--- a/src/lib/components/layout/FormLayout/FormLayoutCustomField.jsx
+++ b/src/lib/components/layout/FormLayout/FormLayoutCustomField.jsx
@@ -5,6 +5,33 @@ import getRootValidationStateClassName from '../../../helpers/getRootValidationS
 import { withProviderContext } from '../../../provider';
 import styles from './FormLayoutCustomField.scss';
 
+const renderLabel = (id, label, labelForId) => {
+  if (labelForId && label) {
+    return (
+      <label
+        htmlFor={labelForId}
+        id={id && `${id}__label`}
+        className={styles.label}
+      >
+        {label}
+      </label>
+    );
+  }
+
+  if (label) {
+    return (
+      <div
+        id={id && `${id}__label`}
+        className={styles.label}
+      >
+        {label}
+      </div>
+    );
+  }
+
+  return null;
+};
+
 export const FormLayoutCustomField = ({
   children,
   fullWidth,
@@ -16,57 +43,28 @@ export const FormLayoutCustomField = ({
   layout,
   required,
   validationState,
-}) => {
-  const renderLabel = () => {
-    if (labelForId && label) {
-      return (
-        <label
-          htmlFor={labelForId}
-          id={id && `${id}__label`}
-          className={styles.label}
-        >
-          {label}
-        </label>
-      );
-    }
-
-    if (label) {
-      return (
-        <div
-          id={id && `${id}__label`}
-          className={styles.label}
-        >
-          {label}
-        </div>
-      );
-    }
-
-    return null;
-  };
-
-  return (
+}) => (
+  <div
+    id={id}
+    className={[
+      styles.root,
+      fullWidth ? styles.isRootFullWidth : '',
+      layout === 'vertical' ? styles.rootLayoutVertical : styles.rootLayoutHorizontal,
+      disabled ? styles.isRootDisabled : '',
+      required ? styles.isRootRequired : '',
+      getRootSizeClassName(innerFieldSize, styles),
+      getRootValidationStateClassName(validationState, styles),
+    ].join(' ')}
+  >
+    {renderLabel(id, label, labelForId)}
     <div
-      id={id}
-      className={[
-        styles.root,
-        fullWidth ? styles.isRootFullWidth : '',
-        layout === 'vertical' ? styles.rootLayoutVertical : styles.rootLayoutHorizontal,
-        disabled ? styles.isRootDisabled : '',
-        required ? styles.isRootRequired : '',
-        getRootSizeClassName(innerFieldSize, styles),
-        getRootValidationStateClassName(validationState, styles),
-      ].join(' ')}
+      id={id && `${id}__field`}
+      className={styles.field}
     >
-      {renderLabel()}
-      <div
-        id={id && `${id}__field`}
-        className={styles.field}
-      >
-        {children}
-      </div>
+      {children}
     </div>
-  );
-};
+  </div>
+);
 
 FormLayoutCustomField.defaultProps = {
   children: null,

--- a/src/lib/components/layout/FormLayout/FormLayoutCustomField.scss
+++ b/src/lib/components/layout/FormLayout/FormLayoutCustomField.scss
@@ -1,9 +1,36 @@
+@use '../../../styles/tools/form-fields/foundation';
 @use '../../../styles/tools/form-fields/box-field-layout';
+@use '../../../styles/tools/form-fields/box-field-sizes';
+@use '../../../styles/tools/form-fields/variants';
 
+// Foundation
 .root {
   @include box-field-layout.in-form-layout();
+  @include variants.visual(custom);
 }
 
+.label {
+  @include foundation.label();
+}
+
+.isRootRequired .label {
+  @include foundation.label-required();
+}
+
+// States
+.isRootStateInvalid {
+  @include variants.validation(invalid);
+}
+
+.isRootStateValid {
+  @include variants.validation(valid);
+}
+
+.isRootStateWarning {
+  @include variants.validation(warning);
+}
+
+// Layouts
 .rootLayoutVertical,
 .rootLayoutHorizontal {
   @include box-field-layout.vertical();
@@ -20,4 +47,17 @@
 
 .isRootFullWidth .field {
   justify-self: stretch;
+}
+
+// Sizes
+.rootSizeSmall {
+  @include box-field-sizes.size(small);
+}
+
+.rootSizeMedium {
+  @include box-field-sizes.size(medium);
+}
+
+.rootSizeLarge {
+  @include box-field-sizes.size(large);
 }

--- a/src/lib/components/layout/FormLayout/README.mdx
+++ b/src/lib/components/layout/FormLayout/README.mdx
@@ -267,6 +267,37 @@ and its styles may affect contained form fields through CSS cascade, don't
 forget to mirror the aforementioned properties to the contained form fields too
 as API options as such are **not** inherited.
 
+### Label Alignment
+
+If you are in a situation with one or more box form fields inside your
+FormLayoutCustomField, you may want to have its label aligned with the fields
+inside. Since it's
+[not quite possible to do this automatically](https://github.com/react-ui-org/react-ui/issues/265)
+due to limited browser support, there is `innerFieldSize` option which accepts
+any of existing box field sizes (small, medium, or large) and is intended right
+for this task.
+
+<Playground>
+  <FormLayout fieldLayout="horizontal" labelWidth="auto">
+    <TextField id="my-text-field-custom-alignment-1" label="A form element" />
+    <FormLayoutCustomField
+      innerFieldSize="medium"
+      label="Custom field label aligned to inner text input"
+    >
+      <TextField
+        id="my-text-field-custom-alignment-2"
+        isLabelVisible={false}
+        label="A form element"
+        placeholder="Text field with invisible label"
+      />
+    </FormLayoutCustomField>
+    <TextField
+      id="my-text-field-custom-alignment-3"
+      label="Another form element"
+    />
+  </FormLayout>
+</Playground>
+
 ### Validation States
 
 Custom fields support the same validation states as regular form fields to

--- a/src/lib/components/layout/FormLayout/README.mdx
+++ b/src/lib/components/layout/FormLayout/README.mdx
@@ -253,13 +253,90 @@ FormLayout elements. FormLayoutCustomFields are designed to work solely inside
 the FormLayout component.
 
 <Playground>
-  <FormLayout fieldLayout="horizontal">
+  <FormLayout fieldLayout="horizontal" labelWidth="auto">
     <TextField id="my-text-field-custom-1" label="A form element" />
-    <FormLayoutCustomField label="Optional label">
-      <Placeholder bordered>Custom content</Placeholder>
+    <FormLayoutCustomField label="Optional custom field label">
+      <Placeholder bordered>Custom field content</Placeholder>
     </FormLayoutCustomField>
     <TextField id="my-text-field-custom-2" label="Another form element" />
   </FormLayout>
+</Playground>
+
+👉 While you can set FormLayoutCustomField as `disabled`, `valid` or `required`
+and its styles may affect contained form fields through CSS cascade, don't
+forget to mirror the aforementioned properties to the contained form fields too
+as API options as such are **not** inherited.
+
+### Validation States
+
+Custom fields support the same validation states as regular form fields to
+provide labels with optional feedback style.
+
+<Playground>
+  <FormLayout fieldLayout="horizontal" labelWidth="auto">
+    <TextField id="my-text-field-custom-validation-1" label="A form element" />
+    <FormLayoutCustomField
+      label="Custom field label in valid state"
+      validationState="valid"
+    >
+      <Placeholder bordered>Custom field content</Placeholder>
+    </FormLayoutCustomField>
+    <TextField
+      id="my-text-field-custom-validation-2"
+      label="Another form element"
+    />
+  </FormLayout>
+</Playground>
+
+### Accessibility
+
+If possible, use the `labelForId` option to provide ID of contained form field
+so the field remains accessible via custom field label.
+
+You can also specify size of contained form field so custom field label is
+properly vertically aligned.
+
+<Playground>
+  {() => {
+    const [isChecked, setIsChecked] = React.useState(false);
+    return (
+      <FormLayout fieldLayout="horizontal" labelWidth="auto">
+        <TextField
+          id="my-text-field-custom-accessibility-1"
+          label="A form element"
+        />
+        <FormLayoutCustomField
+          fullWidth
+          label="Custom field label aligned with medium form field"
+          labelForId="my-text-field-custom-accessibility-2"
+          innerFieldSize="medium"
+        >
+          <Toolbar align="middle" dense>
+            <ToolbarItem>
+              <TextField
+                id="my-text-field-custom-accessibility-2"
+                isLabelVisible={false}
+                label="A form element"
+                placeholder="Text field with invisible label"
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <CheckboxField
+                changeHandler={() => setIsChecked(!isChecked)}
+                checked={isChecked}
+                id="my-checkbox-field-custom-accessibility-1"
+                label="Another form field"
+              />
+            </ToolbarItem>
+          </Toolbar>
+        </FormLayoutCustomField>
+        <TextField
+          id="my-text-field-custom-accessibility-3"
+          label="Another form element"
+        />
+      </FormLayout>
+    )
+  }}
 </Playground>
 
 ## Full Example
@@ -403,7 +480,7 @@ This is a demo of all components supported by FormLayout.
 
 <Props table of={FormLayout} />
 
-### FormLayoutCustomField
+### FormLayoutCustomField API
 
 A place for custom content inside FormLayout.
 
@@ -417,3 +494,13 @@ A place for custom content inside FormLayout.
 | `--rui-form-layout-horizontal-label-limited-width`   | Label width in limited-width layout                          |
 | `--rui-form-layout-horizontal-label-default-width`   | Label width in the default layout                            |
 | `--rui-form-layout-row-gap`                          | Gap between individual rows                                  |
+
+### FormLayoutCustomField Theming
+
+FormLayoutCustomField can be styled using a small subset of
+[other form fields theming options](/customize/theming/forms).
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-form-field-custom-default-surrounding-text-color` | Custom field label color in default state                |
+| `--rui-form-field-custom-disabled-surrounding-text-color` | Custom field label color in disabled-like state         |

--- a/src/lib/components/layout/FormLayout/__tests__/FormLayoutCustomField.test.jsx
+++ b/src/lib/components/layout/FormLayout/__tests__/FormLayoutCustomField.test.jsx
@@ -28,10 +28,14 @@ describe('rendering', () => {
   it('renders correctly with all props', () => {
     const tree = shallow((
       <FormLayoutCustomField
+        disabled
         fullWidth
         label="Label"
+        labelForId="target-id"
         id="my-custom-field"
+        innerFieldSize="small"
         layout="horizontal"
+        required
       >
         <span>Custom text in form 1</span>
         <span>Custom text in form 2</span>

--- a/src/lib/components/layout/FormLayout/__tests__/__snapshots__/FormLayoutCustomField.test.jsx.snap
+++ b/src/lib/components/layout/FormLayout/__tests__/__snapshots__/FormLayoutCustomField.test.jsx.snap
@@ -2,9 +2,7 @@
 
 exports[`rendering renders correctly with a single child 1`] = `
 <div
-  className="root
-      
-      rootLayoutVertical"
+  className="root  rootLayoutVertical    "
 >
   <div
     className="field"
@@ -18,17 +16,16 @@ exports[`rendering renders correctly with a single child 1`] = `
 
 exports[`rendering renders correctly with all props 1`] = `
 <div
-  className="root
-      isRootFullWidth
-      rootLayoutHorizontal"
+  className="root isRootFullWidth rootLayoutHorizontal isRootDisabled isRootRequired rootSizeSmall "
   id="my-custom-field"
 >
-  <div
+  <label
     className="label"
+    htmlFor="target-id"
     id="my-custom-field__label"
   >
     Label
-  </div>
+  </label>
   <div
     className="field"
     id="my-custom-field__field"
@@ -48,9 +45,7 @@ exports[`rendering renders correctly with all props 1`] = `
 
 exports[`rendering renders correctly with multiple children 1`] = `
 <div
-  className="root
-      
-      rootLayoutVertical"
+  className="root  rootLayoutVertical    "
 >
   <div
     className="field"

--- a/src/lib/styles/settings/_form-fields.scss
+++ b/src/lib/styles/settings/_form-fields.scss
@@ -30,6 +30,9 @@ $themeable-variant-states: (
   check: (
     default: (default, checked, disabled, checked-disabled),
   ),
+  custom: (
+    default: (default, disabled),
+  ),
   validation: (
     invalid: (default, checked, disabled, checked-disabled),
     valid: (default, checked, disabled, checked-disabled),

--- a/src/lib/styles/theme/_form-fields.scss
+++ b/src/lib/styles/theme/_form-fields.scss
@@ -1,6 +1,11 @@
 // Variant specific theme options are obtained dynamically because there is way too many of them to
 // maintain manually. See `settings/_form-fields.scss` and `tools/form-fields/_variants.scss` for
 // details.
+//
+// 1. Defaults to zero when neither `--rui-form-field-horizontal-label-padding-y` (optional) nor
+//    `--rui-local-padding-y` (handled by the `size()` mixin in case of box form fields, see
+//    `_box-field-sizes.scss`) is defined. This is useful because FormLayoutCustomField may have no
+//    size specified therefore its label should have no padding at the top.
 
 // Forms fields: common properties
 $label-color: var(--rui-form-field-label-color);
@@ -15,11 +20,11 @@ $required-sign-color: var(--rui-form-field-required-sign-color);
 $horizontal-label-text-align: var(--rui-form-field-horizontal-label-text-align);
 $horizontal-label-min-width: var(--rui-form-field-horizontal-label-min-width);
 $horizontal-label-width: var(--rui-form-field-horizontal-label-width);
-$horizontal-label-padding-top:
+$horizontal-label-padding-y:
   var(
-    --rui-form-field-horizontal-label-padding-top,
+    --rui-form-field-horizontal-label-padding-y,
     calc(var(--rui-form-field-box-border-width) + var(--rui-local-padding-y))
-  );
+  ); // 1.
 $horizontal-label-vertical-alignment: var(--rui-form-field-horizontal-label-vertical-alignment);
 $horizontal-field-vertical-alignment: var(--rui-form-field-horizontal-field-vertical-alignment);
 $horizontal-full-width-label-width: var(--rui-form-field-horizontal-full-width-label-width);

--- a/src/lib/styles/tools/form-fields/_box-field-layout.scss
+++ b/src/lib/styles/tools/form-fields/_box-field-layout.scss
@@ -33,10 +33,16 @@
 // 9.  Help texts and validation messages can take up full width of FormLayout. There is no reason
 //     to make them wrap as they cannot break layout of FormLayout.
 //
-// 10. Align label to input baseline. Achieved with `padding-top` since `align-items: baseline`
-//     unfortunately doesn't work for blank text inputs in Safari. Default to zero when
-//     `--rui-local-padding-y` (handled by the `size()` mixin, see `_box-field-sizes.scss`) is not
-//     defined, eg. for FormLayoutCustomField with no size specified.
+// 10. Visually align label to input baseline. Achieved with `padding-top` and `padding-bottom` due
+//     to two reasons:
+//
+//     * `align-items: baseline` doesn't work for blank text inputs in Safari. See
+//        https://bugs.webkit.org/show_bug.cgi?id=142968 and
+//        https://github.com/react-ui-org/react-ui/issues/265.
+//
+//     * `align-items: baseline` doesn't allow subsequent vertical centering of tall inputs and/or
+//        multiline labels (see `theme.$horizontal-label-vertical-alignment` and
+//        `theme.$horizontal-field-vertical-alignment`).
 //
 // 11. Reset `width` previously set by inline field layout (see `_inline-field-layout.scss`).
 //
@@ -89,20 +95,27 @@
       align-self: theme.$horizontal-label-vertical-alignment; // 13.
       min-width: theme.$horizontal-label-min-width;
 
+      // 10.
       @if ($has-min-tap-target) {
         padding-top:
           calc(
             (#{theme.$check-tap-target-size} - 1rem * #{typography.$line-height-base})
             / 2
-          ); // 10.
+          );
+        padding-bottom:
+          calc(
+            (#{theme.$check-tap-target-size} - 1rem * #{typography.$line-height-base})
+            / 2
+          );
       }
 
+      // 10., 13.
       @else {
-        padding-top: #{theme.$horizontal-label-padding-top}; // 10., 13.
+        padding-top: #{theme.$horizontal-label-padding-y};
+        padding-bottom: #{theme.$horizontal-label-padding-y};
       }
 
       padding-right: settings.$horizontal-inner-gap; // 4.
-      padding-bottom: 0; // 4.
       text-align: theme.$horizontal-label-text-align;
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,8 @@ const path = require('path');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const VisualizerPlugin = require('webpack-visualizer-plugin');
 
-const MAX_DEVELOPMENT_OUTPUT_SIZE = 2150000;
-const MAX_PRODUCTION_OUTPUT_SIZE = 255000;
+const MAX_DEVELOPMENT_OUTPUT_SIZE = 2300000;
+const MAX_PRODUCTION_OUTPUT_SIZE = 270000;
 
 module.exports = (env, argv) => ({
   devtool: argv.mode === 'production'


### PR DESCRIPTION
New options:

- `disabled`
- `innerFieldSize`
- `labelForId`
- `required`
- `validationState`

<img width="872" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/115261539-fd4cb980-a133-11eb-858d-8e80e3565e88.png">

Closes #174.