### PR TITLE
Use BEM-like notation for component's CSS custom properties to improve readability (#243)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,4 +22,4 @@ package-lock.json
 postcss.config.js
 RELEASING.md
 stylelint.config.js
-webpack.config.lib.js
+webpack.config.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ Actions), please follow these guidelines:
 - **One pull request per subject.** Don't combine unrelated changes in a single
   PR unless they are really subtle details such as fix of a typo.
 
+- **Only PRs into `master` branch are listed in changelog.** PRs into other
+  branches are not picked up by release automation.
+
 - **Name your branches according to nature of change.** Choose one of:
 
   - `bc/*` for breaking changes

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ tweaking some of the hundreds theming options available.
 Why another UI library? Because we couldn't find any library that would meet
 these requirements:
 
-- **🎨 Full control over design.** Hundreds of CSS custom properties allow you
-  to customize the design of your app without touching any JS.
+- **🎨 Full control over design, from design tokens to components.** Hundreds of
+  CSS custom properties allow you to customize the design of your app without
+  touching JS.
 
 - **📦 Smart defaults, out of the box.** Create rapid prototypes that look great
   with no additional effort.

--- a/src/docs/customize/theming/forms.mdx
+++ b/src/docs/customize/theming/forms.mdx
@@ -19,8 +19,8 @@ options in common.
 
 General naming convention for CSS custom properties looks as follows:
 
-`--rui-form-field-[<TYPE>]-[<MODIFICATION>]-[<ELEMENT>-[<ELEMENT
-TYPE]]-[<INTERACTION STATE>]-<PROPERTY>`
+`--rui-FormField--[<TYPE>]--[<MODIFICATION>]__[<ELEMENT>--[<ELEMENT
+TYPE]]--[<INTERACTION STATE>]__<PROPERTY>`
 
 Items in brackets are optional. As you read on you will notice some theming
 option groups may have less complicated conventions (that are still subset of
@@ -32,13 +32,13 @@ The following theme options define basic appearance of all form fields.
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-label-color`                       | Label text color                                             |
-| `--rui-form-field-label-font-size`                   | Label font size                                              |
-| `--rui-form-field-help-text-font-size`               | Help text font size                                          |
-| `--rui-form-field-help-text-font-style`              | Help text font style, eg. italic                             |
-| `--rui-form-field-help-text-color`                   | Help text color                                              |
-| `--rui-form-field-required-sign`                     | Text appended to required input labels                       |
-| `--rui-form-field-required-sign-color`               | Color of text appended to required input labels              |
+| `--rui-FormField__label__color`                      | Label text color                                             |
+| `--rui-FormField__label__font-size`                  | Label font size                                              |
+| `--rui-FormField__help-text__font-size`              | Help text font size                                          |
+| `--rui-FormField__help-text__font-style`             | Help text font style, eg. italic                             |
+| `--rui-FormField__help-text__color`                  | Help text color                                              |
+| `--rui-FormField--required__sign`                    | Text appended to required input labels                       |
+| `--rui-FormField--required__sign__color`             | Color of text appended to required input labels              |
 
 ## Horizontal Layout
 
@@ -46,13 +46,13 @@ Options for fields that support horizontal layout.
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-horizontal-label-text-align`       | Text alignment of labels in horizontal layout                |
-| `--rui-form-field-horizontal-label-min-width`        | Minimum width of labels in horizontal layout                 |
-| `--rui-form-field-horizontal-label-width`            | Default width of labels in horizontal layout                 |
-| `--rui-form-field-horizontal-label-padding-y`        | Top and bottom padding to tweak vertical alignment of labels |
-| `--rui-form-field-horizontal-label-vertical-alignment` | Vertical box alignment of labels in horizontal layout      |
-| `--rui-form-field-horizontal-field-vertical-alignment` | Vertical box alignment of fields in horizontal layout      |
-| `--rui-form-field-horizontal-full-width-label-width` | Default width of labels in full-width horizontal layout      |
+| `--rui-FormField--horizontal__label__text-align`     | Text alignment of labels in horizontal layout                |
+| `--rui-FormField--horizontal__label__min-width`      | Minimum width of labels in horizontal layout                 |
+| `--rui-FormField--horizontal__label__width`          | Default width of labels in horizontal layout                 |
+| `--rui-FormField--horizontal__label__padding-y`      | Top and bottom padding to tweak vertical alignment of labels |
+| `--rui-FormField--horizontal__label__vertical-alignment` | Vertical box alignment of labels in horizontal layout    |
+| `--rui-FormField--horizontal__field__vertical-alignment` | Vertical box alignment of fields in horizontal layout    |
+| `--rui-FormField--horizontal--full-width__label__width` | Default width of labels in full-width horizontal layout   |
 
 ## Box Fields
 
@@ -63,11 +63,11 @@ Options shared by box form controls. This includes
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-box-input-width`                   | Default text input and select box width                      |
-| `--rui-form-field-box-input-min-width`               | Minimum text input and select box width                      |
-| `--rui-form-field-box-border-width`                  | Control border width                                         |
-| `--rui-form-field-box-border-radius`                 | Control corner radius                                        |
-| `--rui-form-field-box-placeholder-color`             | Placeholder text color                                       |
+| `--rui-FormField--box__border-width`                 | Control border width                                         |
+| `--rui-FormField--box__border-radius`                | Control corner radius                                        |
+| `--rui-FormField--box__input__width`                 | Default text input and select box width                      |
+| `--rui-FormField--box__input__min-width`             | Minimum text input and select box width                      |
+| `--rui-FormField--box__placeholder__color`           | Placeholder text color                                       |
 
 Example:
 
@@ -93,9 +93,9 @@ Example:
         <style type="text/css">
           {`
           .example--themed-form-fields {
-            --rui-form-field-box-input-width: 300px;
-            --rui-form-field-box-border-width: 2px;
-            --rui-form-field-box-border-radius: 0.5rem;
+            --rui-FormField--box__border-width: 2px;
+            --rui-FormField--box__border-radius: 0.5rem;
+            --rui-FormField--box__input__width: 300px;
           }
         `}
         </style>
@@ -142,7 +142,7 @@ Example:
 
 Theming options for box form controls. Naming convention looks as follows:
 
-`--rui-form-field-box-<VISUAL VARIANT>-<INTERACTION STATE>-<PROPERTY>`
+`--rui-FormField--box--<VISUAL VARIANT>--<INTERACTION STATE>__<PROPERTY>`
 
 Where:
 
@@ -176,12 +176,12 @@ Example:
         <style type="text/css">
           {`
         .example--themed-form-field-variants {
-          --rui-form-field-box-border-width: 0px;
-          --rui-form-field-box-outline-default-box-shadow:
+          --rui-FormField--box__border-width: 0px;
+          --rui-FormField--box--outline--default__box-shadow:
             0.1em 0.1em 0.5em rgba(0, 0, 0, 0.2);
-          --rui-form-field-box-outline-hover-box-shadow:
+          --rui-FormField--box--outline--hover__box-shadow:
             0.1em 0.1em 0.75em rgba(0, 0, 0, 0.3);
-          --rui-form-field-box-outline-focus-box-shadow:
+          --rui-FormField--box--outline--focus__box-shadow:
             inset 0.1em 0.1em 0.25em rgba(0, 0, 0, 0.2);
         }
       `}
@@ -219,7 +219,7 @@ Example:
 
 Available sizes can be adjusted as follows:
 
-`--rui-form-field-box-<SIZE>-<PROPERTY>`
+`--rui-FormField--box--<SIZE>__<PROPERTY>`
 
 Where:
 
@@ -250,8 +250,8 @@ Example:
         <style type="text/css">
           {`
         .example--themed-form-field-sizes {
-          --rui-form-field-box-medium-height: 3rem;
-          --rui-form-field-box-medium-padding-x: 1.25rem;
+          --rui-FormField--box--medium__height: 3rem;
+          --rui-FormField--box--medium__padding-x: 1.25rem;
         }
       `}
         </style>
@@ -292,23 +292,23 @@ and [Toggle](/components/ui/toggle).
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-check-input-size`                  | Size of check inputs                                         |
-| `--rui-form-field-check-input-border-width`          | Border width of check inputs                                 |
-| `--rui-form-field-check-input-focus-box-shadow`      | Box shadow to highlight focused inputs                       |
-| `--rui-form-field-check-tap-target-size`             | Minimum tap target size                                      |
+| `--rui-FormField--check__input__size`                | Size of check inputs                                         |
+| `--rui-FormField--check__input__border-width`        | Border width of check inputs                                 |
+| `--rui-FormField--check__input--focus__box-shadow`   | Box shadow to highlight focused inputs                       |
+| `--rui-FormField--check__tap-target-size`            | Minimum tap target size                                      |
 
 Interaction states:
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-check-default-border-color`        | Border color of unchecked inputs                             |
-| `--rui-form-field-check-default-check-background-color` | Background color of unchecked inputs                      |
-| `--rui-form-field-check-checked-border-color`        | Border color of checked inputs                               |
-| `--rui-form-field-check-checked-check-background-color` | Background color of checked inputs                        |
-| `--rui-form-field-check-disabled-border-color`        | Border color of disabled unchecked inputs                   |
-| `--rui-form-field-check-disabled-check-background-color` | Background color of disabled unchecked inputs            |
-| `--rui-form-field-check-checked-disabled-border-color` | Border color of disabled checked inputs                    |
-| `--rui-form-field-check-checked-disabled-check-background-color` | Background color of disabled checked inputs      |
+| `--rui-FormField--check--default__border-color`      | Border color of unchecked inputs                             |
+| `--rui-FormField--check--default__check-background-color` | Background color of unchecked inputs                    |
+| `--rui-FormField--check--checked__border-color`      | Border color of checked inputs                               |
+| `--rui-FormField--check--checked__check-background-color` | Background color of checked inputs                      |
+| `--rui-FormField--check--disabled__border-color`     | Border color of disabled unchecked inputs                    |
+| `--rui-FormField--check--disabled__check-background-color` | Background color of disabled unchecked inputs          |
+| `--rui-FormField--check--checked-disabled__border-color` | Border color of disabled checked inputs                  |
+| `--rui-FormField--check--checked-disabled__check-background-color` | Background color of disabled checked inputs    |
 
 Example:
 
@@ -322,9 +322,9 @@ Example:
         <style type="text/css">
           {`
             .example--themed-check-fields {
-              --rui-form-field-check-input-border-width: 2px;
-              --rui-form-field-check-checked-border-color: LightSeaGreen;
-              --rui-form-field-check-checked-check-background-color: MediumAquamarine;
+              --rui-FormField--check__input__border-width: 2px;
+              --rui-FormField--check--checked__border-color: LightSeaGreen;
+              --rui-FormField--check--checked__check-background-color: MediumAquamarine;
             }
           `}
         </style>
@@ -404,7 +404,7 @@ Example:
 Theming options for validation states are shared by all form components. Naming
 convention looks as follows:
 
-`--rui-form-field-<VALIDATION STATE>-<INTERACTION STATE>-<PROPERTY>`
+`--rui-FormField--<VALIDATION STATE>--<INTERACTION STATE>__<PROPERTY>`
 
 Where:
 
@@ -446,12 +446,12 @@ Example:
         <style type="text/css">
           {`
         .example--themed-form-field-validation-states {
-          --rui-form-field-valid-default-color: white;
-          --rui-form-field-valid-default-border-color: LightSeaGreen;
-          --rui-form-field-valid-default-background: MediumAquamarine;
-          --rui-form-field-valid-default-check-background-color: MediumAquamarine;
-          --rui-form-field-valid-default-surrounding-text-color: DarkSlateGray;
-          --rui-form-field-valid-checked-check-background-color: MediumAquamarine;
+          --rui-FormField--valid--default__color: white;
+          --rui-FormField--valid--default__border-color: LightSeaGreen;
+          --rui-FormField--valid--default__background: MediumAquamarine;
+          --rui-FormField--valid--default__check-background-color: MediumAquamarine;
+          --rui-FormField--valid--default__surrounding-text-color: DarkSlateGray;
+          --rui-FormField--valid--checked__check-background-color: MediumAquamarine;
         }
       `}
         </style>
@@ -575,8 +575,8 @@ cursor on hover so users know the fields cannot be used.
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-disabled-cursor`                   | Cursor to show on hovering disabled form fields              |
-| `--rui-form-field-disabled-opacity`                  | Opacity of disabled form fields (inc. label and help text)   |
+| `--rui-FormField--disabled__cursor`                  | Cursor to show on hovering disabled form fields              |
+| `--rui-FormField--disabled__opacity`                 | Opacity of disabled form fields (inc. label and help text)   |
 
 Should your design require custom styling of disabled fields, individual field
 types and validation states can be fine-tuned by several theming options
@@ -611,39 +611,41 @@ Example:
           {`
           .example--themed-form-field-disabled-state {
             /*_Common_*/
-            --rui-form-field-disabled-opacity: 1;
+            --rui-FormField--disabled__opacity: 1;
             /*_Check fields_*/
-            --rui-form-field-check-disabled-border-color: silver;
-            --rui-form-field-check-disabled-check-background-color: gainsboro;
-            --rui-form-field-check-disabled-surrounding-text-color: silver;
-            --rui-form-field-check-checked-disabled-border-color: silver;
-            --rui-form-field-check-checked-disabled-check-background-color: gainsboro;
+            --rui-FormField--check--disabled__border-color: silver;
+            --rui-FormField--check--disabled__check-background-color: gainsboro;
+            --rui-FormField--check--disabled__surrounding-text-color: silver;
+            --rui-FormField--check--checked-disabled__border-color: silver;
+            --rui-FormField--check--checked-disabled__check-background-color: gainsboro;
             /*_Outline box fields_*/
-            --rui-form-field-box-outline-disabled-color: DarkGray;
-            --rui-form-field-box-outline-disabled-border-color: silver;
-            --rui-form-field-box-outline-disabled-background: gainsboro;
-            --rui-form-field-box-outline-disabled-surrounding-text-color: silver;
+            --rui-FormField--box--outline--disabled__color: DarkGray;
+            --rui-FormField--box--outline--disabled__border-color: silver;
+            --rui-FormField--box--outline--disabled__background: gainsboro;
+            --rui-FormField--box--outline--disabled__surrounding-text-color: silver;
             /*_Invalid state_*/
-            --rui-form-field-invalid-disabled-color: DarkGray;
-            --rui-form-field-invalid-disabled-border-color: silver;
-            --rui-form-field-invalid-disabled-background: gainsboro;
-            --rui-form-field-invalid-disabled-check-background-color: gainsboro;
-            --rui-form-field-invalid-disabled-surrounding-text-color: silver;
-            --rui-form-field-invalid-checked-disabled-check-background-color: gainsboro;
+            --rui-FormField--invalid--disabled__color: DarkGray;
+            --rui-FormField--invalid--disabled__border-color: silver;
+            --rui-FormField--invalid--disabled__background: gainsboro;
+            --rui-FormField--invalid--disabled__check-background-color: gainsboro;
+            --rui-FormField--invalid--disabled__surrounding-text-color: silver;
+            --rui-FormField--invalid--checked-disabled__check-background-color:
+            gainsboro;
             /*_Warning state_*/
-            --rui-form-field-warning-disabled-color: DarkGray;
-            --rui-form-field-warning-disabled-border-color: silver;
-            --rui-form-field-warning-disabled-background: gainsboro;
-            --rui-form-field-warning-disabled-check-background-color: gainsboro;
-            --rui-form-field-warning-disabled-surrounding-text-color: silver;
-            --rui-form-field-warning-checked-disabled-check-background-color: gainsboro;
+            --rui-FormField--warning--disabled__color: DarkGray;
+            --rui-FormField--warning--disabled__border-color: silver;
+            --rui-FormField--warning--disabled__background: gainsboro;
+            --rui-FormField--warning--disabled__check-background-color: gainsboro;
+            --rui-FormField--warning--disabled__surrounding-text-color: silver;
+            --rui-FormField--warning--checked-disabled__check-background-color:
+            gainsboro;
             /*_Valid state_*/
-            --rui-form-field-valid-disabled-color: DarkGray;
-            --rui-form-field-valid-disabled-border-color: silver;
-            --rui-form-field-valid-disabled-background: gainsboro;
-            --rui-form-field-valid-disabled-check-background-color: gainsboro;
-            --rui-form-field-valid-disabled-surrounding-text-color: silver;
-            --rui-form-field-valid-checked-disabled-check-background-color: gainsboro;
+            --rui-FormField--valid--disabled__color: DarkGray;
+            --rui-FormField--valid--disabled__border-color: silver;
+            --rui-FormField--valid--disabled__background: gainsboro;
+            --rui-FormField--valid--disabled__check-background-color: gainsboro;
+            --rui-FormField--valid--disabled__surrounding-text-color: silver;
+            --rui-FormField--valid--checked-disabled__check-background-color: gainsboro;
           }
         `}
         </style>

--- a/src/docs/customize/theming/overview.mdx
+++ b/src/docs/customize/theming/overview.mdx
@@ -11,11 +11,12 @@ From the very beginning, React UI has been designed with a great emphasis on
 customizability. We decided to leverage CSS custom properties for this feature
 for two main reasons:
 
-1. We believe in **power of native CSS**. Preprocessors are still a thing, but
-   it's not necessary to go as far as for CSS-in-JS to make a UI customizable.
+1. We take advantage of possibilities of **native CSS**. Preprocessors are still
+   a thing, but it's not necessary to go as far as for CSS-in-JS to make a UI
+   customizable.
 
 2. Thanks to its JavaScript API, CSS custom properties are both **readable and
-   writable from JS code**.
+   writable by JS**.
 
 ## Theming Options
 
@@ -23,55 +24,92 @@ CSS custom properties are used to define common visual properties like colors,
 fonts, borders, shadows, or spacing. They come prefixed with `rui-` so they
 don't get in way of other custom properties in your project.
 
-Example `theme.scss`:
+Theming options come grouped into three sections according to what they
+describe:
 
-```scss
-:root {
-  // Brand colors
-  --rui-color-primary: #00778b;
-  --rui-color-primary-light: #{lighten(#00778b, 70%)};
-  --rui-color-primary-dark: #{darken(#00778b, 4%)};
-  --rui-color-primary-darker: #{darken(#00778b, 8%)};
-  --rui-color-on-primary: #fff;
-  --rui-color-secondary: #fa4616;
-  --rui-color-secondary-light: #{lighten(#fa4616, 45%)};
-  --rui-color-secondary-dark: #{darken(#fa4616, 4%)};
-  --rui-color-secondary-darker: #{darken(#fa4616, 8%)};
-  --rui-color-on-secondary: #fff;
-}
-```
-
-It is also possible to adjust some properties on individual components level,
-preferably by reusing the global settings:
-
-```scss
-:root {
-  // Alerts: common properties
-  --rui-alert-border-width: var(--rui-border-width);
-  --rui-alert-border-radius: var(--rui-border-radius);
-  --rui-alert-padding: var(--rui-spacing-2);
-}
-```
+1. design tokens,
+2. layout components,
+3. UI components.
 
 You can adjust any of these options in your styles. See the
 [default theme](https://github.com/react-ui-org/react-ui/blob/master/src/lib/theme.scss)
 for the full list of available settings.
+
+### Design Tokens
+
+Design tokens are special variables that define the smallest pieces of a design
+language, especially colors, typography, or spacing.
+
+Design token names shouldn't be complex nor long so they are simply lowercase
+and hyphenated:
+
+```css
+:root {
+  --rui-spacing-0: 0;
+  --rui-spacing-1: 0.25rem;
+  --rui-spacing-2: 0.5rem;
+  --rui-spacing-3: 0.75rem;
+  --rui-spacing-4: 1rem;
+  --rui-spacing-5: 1.5rem;
+  --rui-spacing-6: 2rem;
+  --rui-spacing-7: 3rem;
+}
+```
 
 ️👉 Please note that **breakpoint values are exported as read-only** since CSS
 custom properties
 [cannot be used within media queries](https://www.w3.org/TR/css-variables-1/#using-variables)
 (because media query is not a CSS property).
 
+### Layouts and UI Components
+
+It is also possible to adjust some properties on individual components level,
+preferably by reusing design tokens.
+
+Layouts and UI component names use naming convention that is familiar to many
+web developers because it looks like BEM (or SUIT CSS, more precisely):
+
+`--rui-<ComponentName>--[<modification(s)>]__[<element>]--[<modification(s)>]__<property>--[<modification>]`
+
+Where:
+
+* `<ComponentName>` stands for actual component name (eg. `Button`,
+  `FormField` etc.) with a reasonable exception to form fields whose settings
+  are widely shared and therefore grouped as `FormField` options.
+* `<modifications(s)>` can be one or more modifiers, typically a variant (eg.
+  `primary`, `filled`, `box`) or interaction state (`default`, `hover`,
+  `focus`, `active`, `disabled`).
+* `<element>` stands for a nested element of the component.
+* `<property>` is usually a CSS property (eg. `color`, `background`,
+  `background-color`, `width`, `box-shadow`), or a brief property description
+  where a CSS property wouldn't tell enough (eg. `initial-offset`,
+  `check-background-color`, `tap-target-size`).
+
+Example component theming options:
+
+```css
+:root {
+  --rui-Button--filled--primary--default__color: var(--rui-color-on-primary);
+  --rui-Button--filled--primary--default__border-color: var(--rui-color-primary);
+  --rui-Button--filled--primary--default__background: var(--rui-color-primary);
+  --rui-Button--filled--primary--default__box-shadow: none;
+  --rui-Button--filled--primary--hover__color: var(--rui-color-on-primary);
+  --rui-Button--filled--primary--hover__border-color: var(--rui-color-primary-dark);
+  --rui-Button--filled--primary--hover__background: var(--rui-color-primary-dark);
+  --rui-Button--filled--primary--hover__box-shadow: none;
+}
+```
+
 ## Best Practices
 
-It's a good idea to start with changing the **global settings first**. Widely
-reused settings such as colors, typography, borders or spacing values should be
-adjusted first because they define the basic appearance of all components.
+It's a good idea to start with changing **design tokens first**. Widely reused
+settings such as colors, typography, borders, or spacing values should be
+adjusted first because they define basic appearance of all components.
 
 Having finished the customization at the global level, you can **then proceed to
-customize the appearance of individual components** — if necessary at all. Even
-then you should also reuse existing global settings as much as possible to
+customizing the appearance of individual components** — if necessary at all.
+Even then you should also reuse existing design tokens as much as possible to
 ensure that your UI is consistent and works as a system.
 
 For the same reason, if you have any custom components in your UI, you should
-**reuse the global theming options in your own CSS**, too.
+**reuse design tokens in your own CSS** too.

--- a/src/docs/foundation/accessibility.mdx
+++ b/src/docs/foundation/accessibility.mdx
@@ -8,6 +8,10 @@ route: /foundation/accessibility
 
 React UI bakes accessibility principles right into its core.
 
+👉 You can adjust all custom properties on this page (and more) in your theme by
+overriding values in the
+[design tokens](/customize/theming/overview#design-tokens) section.
+
 ## Touch Friendliness
 
 The active area of interactive elements should be properly sized so that the
@@ -38,7 +42,7 @@ fields do not add any extra vertical space because it is already provided by
 `FormLayout` row gap. Remember to check that form fields in your `FormLayout`
 are properly spaced and interactive elements do not collide should you decide to
 make any changes to `--rui-tap-target-size`,
-`--rui-form-field-check-tap-target-size` or `--rui-form-layout-row-gap` options.
+`--rui-FormField--check__tap-target-size` or `--rui-FormLayout__row-gap` options.
 
 Horizontal padding is never added to form fields box model so it does not make
 their horizontal alignment complicated.

--- a/src/docs/foundation/breakpoints.mdx
+++ b/src/docs/foundation/breakpoints.mdx
@@ -30,4 +30,5 @@ seamless experience for your users.
 cannot be used inside media queries (media query is
 [not a CSS property](https://stackoverflow.com/q/40722882)), changing their
 values will have no effect. If you need to adjust the breakpoint values, you
-must override the `$values` SCSS map in `styles/settings/_breakpoints.scss`.
+must override the `$values` SCSS map defined in
+`styles/settings/_breakpoints.scss`.

--- a/src/docs/foundation/colors.mdx
+++ b/src/docs/foundation/colors.mdx
@@ -12,6 +12,10 @@ Colors help you communicate the structure of your UI, emphasize any important
 information, or signal different states of the UI. **Use colors intentionally**
 — they are not a decoration, they should always serve a purpose.
 
+👉 You can adjust all custom properties on this page (and more) in your theme by
+overriding values in the
+[design tokens](/customize/theming/overview#design-tokens) section.
+
 ## General Guidelines
 
 We have different shades for all of our **brand and UI colors** in React UI. The

--- a/src/docs/foundation/spacing.mdx
+++ b/src/docs/foundation/spacing.mdx
@@ -10,6 +10,10 @@ With only few reasonable exceptions, all margins and paddings in React UI use
 predefined spacing values. Using only the values from the spacing scale will
 help you keep your UI consistent.
 
+👉 You can adjust all custom properties on this page (and more) in your theme by
+overriding values in the
+[design tokens](/customize/theming/overview#design-tokens) section.
+
 | Spacing name | Value    | Usage in CSS      | Usage in SCSS   | Usage in HTML/JSX* |
 |--------------|---------:|-------------------|-----------------|--------------------|
 | 0            | 0        | `--rui-spacing-0` | `spacing.of(0)` | `class="mt-0"`     |

--- a/src/docs/foundation/typography.mdx
+++ b/src/docs/foundation/typography.mdx
@@ -11,12 +11,11 @@ import { Playground } from 'docz'
 Typography is the basic means to present information to users. It also serves to
 communicate the hierarchy of a page.
 
-React UI is designed with
-[Titillium Web](https://fonts.google.com/specimen/Titillium+Web) font,
-a geometric sans with a wide variety of weights and styles. You can change it to
-a custom font by [overriding](/customize/theming/overview) the
-`--rui-typography-font-family-base` CSS custom property. Font size and weight
-values can be customised as well.
+👉 You can adjust all custom properties on this page (and more) in your theme by
+overriding values in the
+[design tokens](/customize/theming/overview#design-tokens) section.
+
+Basic typography showcase:
 
 <Playground>
   <h4 className="typography-size-0">Font size 0 (base font size)</h4>
@@ -58,3 +57,37 @@ values can be customised as well.
     <li>Ordered list item 3</li>
   </ol>
 </Playground>
+
+React UI is designed with
+[Titillium Web](https://fonts.google.com/specimen/Titillium+Web) font,
+a geometric sans with a wide variety of weights and styles. You can change it to
+a custom font by [overriding](/customize/theming/overview) the
+`--rui-typography-font-family-base` CSS custom property:
+
+```css
+:root {
+  --rui-typography-font-family-base: 'Titillium Web', helvetica, roboto, arial, sans-serif;
+}
+```
+
+Font size and weight values can be customised as well:
+
+```css
+:root {
+  --rui-typography-font-size-base: 100%;
+  --rui-typography-line-height-base: 1.5;
+  --rui-typography-size-0: 1rem;
+  --rui-typography-size-1: 1.125rem;
+  --rui-typography-size-2: 1.266rem;
+  --rui-typography-size-3: 1.424rem;
+  --rui-typography-size-4: 1.602rem;
+  --rui-typography-size-5: 1.802rem;
+  --rui-typography-size-small: 0.889rem;
+  --rui-typography-size-smaller: 0.75rem;
+  --rui-typography-font-weight-thin: 100;
+  --rui-typography-font-weight-light: 300;
+  --rui-typography-font-weight-regular: 400;
+  --rui-typography-font-weight-medium: 500;
+  --rui-typography-font-weight-bold: 700;
+}
+```

--- a/src/docs/index.mdx
+++ b/src/docs/index.mdx
@@ -23,8 +23,9 @@ tweaking some of the hundreds theming options available.
 Why another UI library? Because we couldn't find any library that would meet
 these requirements:
 
-- **🎨 Full control over design.** Hundreds of CSS custom properties allow you
-  to customize the design of your app without touching any JS.
+- **🎨 Full control over design, from design tokens to components.** Hundreds of
+  CSS custom properties allow you to customize the design of your app without
+  touching JS.
 
 - **📦 Zero configuration needed.** Create rapid prototypes that look great with
   smart defaults and no additional effort.

--- a/src/lib/components/layout/FormLayout/FormLayout.scss
+++ b/src/lib/components/layout/FormLayout/FormLayout.scss
@@ -38,15 +38,15 @@
 }
 
 .hasRootLabelWidthDefault {
-  --rui-local-label-width: #{theme.$horizontal-label-default-width}; // 1., 2.
+  --rui-local-label-width: #{theme.$horizontal-label-width}; // 1., 2.
 }
 
 .hasRootLabelWidthAuto {
-  --rui-local-label-width: #{theme.$horizontal-label-auto-width}; // 4.
+  --rui-local-label-width: #{theme.$horizontal-label-width-auto}; // 4.
 }
 
 .hasRootLabelWidthLimited {
-  --rui-local-label-width: #{theme.$horizontal-label-limited-width}; // 4.
+  --rui-local-label-width: #{theme.$horizontal-label-width-limited}; // 4.
 }
 
 .hasRootLabelWidthCustom {

--- a/src/lib/components/layout/FormLayout/README.mdx
+++ b/src/lib/components/layout/FormLayout/README.mdx
@@ -521,10 +521,10 @@ A place for custom content inside FormLayout.
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-layout-horizontal-label-auto-width`      | Label width in automatic layout                              |
-| `--rui-form-layout-horizontal-label-limited-width`   | Label width in limited-width layout                          |
-| `--rui-form-layout-horizontal-label-default-width`   | Label width in the default layout                            |
-| `--rui-form-layout-row-gap`                          | Gap between individual rows                                  |
+| `--rui-FormLayout__row-gap`                          | Gap between individual rows                                  |
+| `--rui-FormLayout--horizontal__label__width`         | Default label width                                          |
+| `--rui-FormLayout--horizontal__label__width--auto`   | Label width in automatic layout                              |
+| `--rui-FormLayout--horizontal__label__width--limited` | Label width in limited-width layout                         |
 
 ### FormLayoutCustomField Theming
 
@@ -533,5 +533,5 @@ FormLayoutCustomField can be styled using a small subset of
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-custom-default-surrounding-text-color` | Custom field label color in default state                |
-| `--rui-form-field-custom-disabled-surrounding-text-color` | Custom field label color in disabled-like state         |
+| `--rui-FormField--custom--default__surrounding-text-color` | Custom field label color in default state              |
+| `--rui-FormField--custom--disabled__surrounding-text-color` | Custom field label color in disabled-like state       |

--- a/src/lib/components/layout/FormLayout/_theme.scss
+++ b/src/lib/components/layout/FormLayout/_theme.scss
@@ -1,4 +1,4 @@
-$horizontal-label-auto-width: var(--rui-form-layout-horizontal-label-auto-width);
-$horizontal-label-limited-width: var(--rui-form-layout-horizontal-label-limited-width);
-$horizontal-label-default-width: var(--rui-form-layout-horizontal-label-default-width);
-$row-gap: var(--rui-form-layout-row-gap);
+$row-gap: var(--rui-FormLayout__row-gap);
+$horizontal-label-width: var(--rui-FormLayout--horizontal__label__width);
+$horizontal-label-width-auto: var(--rui-FormLayout--horizontal__label__width--auto);
+$horizontal-label-width-limited: var(--rui-FormLayout--horizontal__label__width--limited);

--- a/src/lib/components/layout/Grid/Grid.scss
+++ b/src/lib/components/layout/Grid/Grid.scss
@@ -23,41 +23,31 @@
 // 3. Any valid auto-flow algorithm can be used. It's applied globally for all breakpoints.
 
 @use '../../../styles/tools/spacing';
+@use 'theme';
 @use 'tools';
 
 .root {
-  $properties: (
-    columns: var(--rui-grid-columns),
-    column-gap: var(--rui-grid-column-gap),
-    rows: var(--rui-grid-rows),
-    row-gap: var(--rui-grid-row-gap),
-    align-content: var(--rui-grid-align-content),
-    align-items: var(--rui-grid-align-items),
-    justify-content: var(--rui-grid-justify-content),
-    justify-items: var(--rui-grid-justify-items),
-  );
-
-  @include tools.assign-responsive-custom-properties($properties); // 1.
+  @include tools.assign-responsive-custom-properties(theme.$responsive-properties); // 1.
   @include spacing.bottom(layouts);
 
   display: grid;
   grid-template-columns: var(--rui-local-columns); // 2.
   grid-template-rows: var(--rui-local-rows); // 2.
   grid-gap: var(--rui-local-row-gap) var(--rui-local-column-gap); // 2.
-  grid-auto-flow: var(--rui-local-auto-flow, var(--rui-grid-auto-flow)); // 3.
-  align-content: var(--rui-local-align-content, var(--rui-grid-align-content)); // 2.
-  align-items: var(--rui-local-align-items, var(--rui-grid-align-items)); // 2.
-  justify-content: var(--rui-local-justify-content, var(--rui-grid-justify-content)); // 2.
-  justify-items: var(--rui-local-justify-items, var(--rui-grid-justify-items)); // 2.
+  grid-auto-flow: var(--rui-local-auto-flow, theme.$auto-flow); // 3.
+  align-content: var(--rui-local-align-content, #{map-get(theme.$responsive-properties, align-content)}); // 2.
+  align-items: var(--rui-local-align-items, #{map-get(theme.$responsive-properties, align-items)}); // 2.
+  justify-content: var(--rui-local-justify-content, #{map-get(theme.$responsive-properties, justify-content)}); // 2.
+  justify-items: var(--rui-local-justify-items, #{map-get(theme.$responsive-properties, justify-items)}); // 2.
 }
 
 .span {
-  $properties: (
+  $responsive-properties: (
     column-span: 1,
     row-span: 1,
   );
 
-  @include tools.assign-responsive-custom-properties($properties); // 1.
+  @include tools.assign-responsive-custom-properties($responsive-properties); // 1.
 
   grid-column: span var(--rui-local-column-span, 1); // 2.
   grid-row: span var(--rui-local-row-span, 1); // 2.

--- a/src/lib/components/layout/Grid/README.mdx
+++ b/src/lib/components/layout/Grid/README.mdx
@@ -236,8 +236,22 @@ understand available options.
 
 <Props table of={Grid} />
 
-### GridSpan
+### GridSpan API
 
 Wrapper for content that should span multiple rows or columns.
 
 <Props table of={GridSpan} />
+
+## Theming
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Grid__columns`                                | Default columns layout                                       |
+| `--rui-Grid__column-gap`                             | Default column gap                                           |
+| `--rui-Grid__rows`                                   | Default rows layout                                          |
+| `--rui-Grid__row-gap`                                | Default row gap                                              |
+| `--rui-Grid__align-content`                          | Default vertical alignment of the layout                     |
+| `--rui-Grid__align-items`                            | Default vertical alignment of grid items                     |
+| `--rui-Grid__justify-content`                        | Default horizontal alignment of the layout                   |
+| `--rui-Grid__justify-items`                          | Default horizontal alignment of grid items                   |
+| `--rui-Grid__auto-flow`                              | Default auto-flow algorithm                                  |

--- a/src/lib/components/layout/Grid/_theme.scss
+++ b/src/lib/components/layout/Grid/_theme.scss
@@ -1,0 +1,12 @@
+$auto-flow: var(--rui-Grid__auto-flow);
+
+$responsive-properties: (
+  columns: var(--rui-Grid__columns),
+  column-gap: var(--rui-Grid__column-gap),
+  rows: var(--rui-Grid__rows),
+  row-gap: var(--rui-Grid__row-gap),
+  align-content: var(--rui-Grid__align-content),
+  align-items: var(--rui-Grid__align-items),
+  justify-content: var(--rui-Grid__justify-content),
+  justify-items: var(--rui-Grid__justify-items),
+);

--- a/src/lib/components/layout/List/List.scss
+++ b/src/lib/components/layout/List/List.scss
@@ -1,4 +1,5 @@
 @use '../../../styles/tools/spacing';
+@use 'theme';
 
 .root {
   @include spacing.bottom(layouts);
@@ -14,7 +15,7 @@
 
 .item {
   width: 100%;
-  margin-bottom: spacing.of(2);
+  margin-bottom: theme.$row-gap;
 
   &:last-child {
     margin-bottom: 0;

--- a/src/lib/components/layout/List/README.mdx
+++ b/src/lib/components/layout/List/README.mdx
@@ -101,8 +101,14 @@ put it inside a flex or grid layout).
 
 <Props table of={List} />
 
-### ListItem
+### ListItem API
 
 A wrapper for individual list items.
 
 <Props table of={ListItem} />
+
+## Theming
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-List__row-gap`                                | Gap between list items                                       |

--- a/src/lib/components/layout/List/_theme.scss
+++ b/src/lib/components/layout/List/_theme.scss
@@ -1,0 +1,1 @@
+$row-gap: var(--rui-List__row-gap);

--- a/src/lib/components/layout/Toolbar/README.mdx
+++ b/src/lib/components/layout/Toolbar/README.mdx
@@ -299,14 +299,21 @@ Try resizing the playground below to see how it works.
 
 <Props table of={Toolbar} />
 
-### ToolbarGroup
+### ToolbarGroup API
 
 A wrapper for grouping ToolbarItems together.
 
 <Props table of={ToolbarGroup} />
 
-### ToolbarItem
+### ToolbarItem API
 
 A wrapper for individual toolbar items.
 
 <Props table of={ToolbarItem} />
+
+## Theming
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Toolbar__gap`                                 | Gap between toolbar items                                    |
+| `--rui-Toolbar__gap--dense`                          | Dense gap between toolbar items                              |

--- a/src/lib/components/layout/Toolbar/Toolbar.scss
+++ b/src/lib/components/layout/Toolbar/Toolbar.scss
@@ -10,16 +10,16 @@
 }
 
 .toolbar {
-  @include spacing.bottom(layouts, $compensation: theme.$spacing);
+  @include spacing.bottom(layouts, $compensation: theme.$gap);
 
-  margin: calc(-1 * #{theme.$spacing});
+  margin: calc(-1 * #{theme.$gap});
 }
 
 .item {
   display: flex; // 1.
   flex: none;
   flex-direction: column; // 1.
-  margin: theme.$spacing;
+  margin: theme.$gap;
 }
 
 .isAlignedToTop {
@@ -63,11 +63,11 @@
 }
 
 .isDense {
-  margin: calc(-1 * #{theme.$spacing-dense});
+  margin: calc(-1 * #{theme.$gap-dense});
 }
 
 .isDense .item {
-  margin: theme.$spacing-dense;
+  margin: theme.$gap-dense;
 }
 
 .isDense > .isDense {
@@ -75,10 +75,10 @@
 }
 
 .toolbar.isDense {
-  @include spacing.bottom(layouts, $compensation: theme.$spacing-dense);
+  @include spacing.bottom(layouts, $compensation: theme.$gap-dense);
 }
 
 .toolbar:not(.isDense) > .isDense,
 .group:not(.isDense) > .isDense {
-  margin: theme.$spacing-dense;
+  margin: theme.$gap-dense;
 }

--- a/src/lib/components/layout/Toolbar/_theme.scss
+++ b/src/lib/components/layout/Toolbar/_theme.scss
@@ -1,2 +1,2 @@
-$spacing: var(--rui-toolbar-spacing);
-$spacing-dense: var(--rui-toolbar-spacing-dense);
+$gap: var(--rui-Toolbar__gap);
+$gap-dense: var(--rui-Toolbar__gap--dense);

--- a/src/lib/components/ui/Alert/README.mdx
+++ b/src/lib/components/ui/Alert/README.mdx
@@ -166,3 +166,30 @@ click on the close button:
 ## API
 
 <Props table of={ParsableAlert} />
+
+## Theming
+
+### Common Theming Options
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Alert__padding`                               | Padding between border and message                           |
+| `--rui-Alert__font-weight`                           | Message font weight                                          |
+| `--rui-Alert__border-width`                          | Border width                                                 |
+| `--rui-Alert__border-radius`                         | Border radius                                                |
+| `--rui-Alert__emphasis__font-weight`                 | Font weight of text emphasised with `<strong>`               |
+| `--rui-Alert__stripe__width`                         | Width of the border at the start of the Alert                |
+
+### Theming Types
+
+It's possible to adjust the theme of specific alert type. Naming convention
+looks as follows:
+
+`--rui-Alert--<TYPE>__<PROPERTY>`
+
+Where:
+
+- `<TYPE>` is one of `success`, `warning`, `error`, `info`, `note`, or `help`
+  (see [alert types](#alert-types) and [API](#api))
+- `<PROPERTY>` is one of `foreground-color` (color of border, icon, links, and
+  emphasis), `background-color`, or `text-color`.

--- a/src/lib/components/ui/Alert/_theme.scss
+++ b/src/lib/components/ui/Alert/_theme.scss
@@ -1,39 +1,39 @@
-$font-weight: var(--rui-alert-font-weight);
-$emphasis-font-weight: var(--rui-alert-emphasis-font-weight);
-$border-width: var(--rui-alert-border-width);
-$border-radius: var(--rui-alert-border-radius);
-$stripe-width: var(--rui-alert-stripe-width);
-$padding: var(--rui-alert-padding);
+$padding: var(--rui-Alert__padding);
+$font-weight: var(--rui-Alert__font-weight);
+$border-width: var(--rui-Alert__border-width);
+$border-radius: var(--rui-Alert__border-radius);
+$emphasis-font-weight: var(--rui-Alert__emphasis__font-weight);
+$stripe-width: var(--rui-Alert__stripe__width);
 
 $types: (
   success: (
-    background-color: var(--rui-alert-success-background-color),
-    foreground-color: var(--rui-alert-success-foreground-color),
-    text-color: var(--rui-alert-success-text-color),
+    background-color: var(--rui-Alert--success__background-color),
+    foreground-color: var(--rui-Alert--success__foreground-color),
+    text-color: var(--rui-Alert--success__text-color),
   ),
   warning: (
-    background-color: var(--rui-alert-warning-background-color),
-    foreground-color: var(--rui-alert-warning-foreground-color),
-    text-color: var(--rui-alert-warning-text-color),
+    background-color: var(--rui-Alert--warning__background-color),
+    foreground-color: var(--rui-Alert--warning__foreground-color),
+    text-color: var(--rui-Alert--warning__text-color),
   ),
   error: (
-    background-color: var(--rui-alert-error-background-color),
-    foreground-color: var(--rui-alert-error-foreground-color),
-    text-color: var(--rui-alert-error-text-color),
+    background-color: var(--rui-Alert--error__background-color),
+    foreground-color: var(--rui-Alert--error__foreground-color),
+    text-color: var(--rui-Alert--error__text-color),
   ),
   info: (
-    background-color: var(--rui-alert-info-background-color),
-    foreground-color: var(--rui-alert-info-foreground-color),
-    text-color: var(--rui-alert-info-text-color),
+    background-color: var(--rui-Alert--info__background-color),
+    foreground-color: var(--rui-Alert--info__foreground-color),
+    text-color: var(--rui-Alert--info__text-color),
   ),
   help: (
-    background-color: var(--rui-alert-help-background-color),
-    foreground-color: var(--rui-alert-help-foreground-color),
-    text-color: var(--rui-alert-help-text-color),
+    background-color: var(--rui-Alert--help__background-color),
+    foreground-color: var(--rui-Alert--help__foreground-color),
+    text-color: var(--rui-Alert--help__text-color),
   ),
   note: (
-    background-color: var(--rui-alert-note-background-color),
-    foreground-color: var(--rui-alert-note-foreground-color),
-    text-color: var(--rui-alert-note-text-color),
+    background-color: var(--rui-Alert--note__background-color),
+    foreground-color: var(--rui-Alert--note__foreground-color),
+    text-color: var(--rui-Alert--note__text-color),
   ),
 );

--- a/src/lib/components/ui/Button/README.mdx
+++ b/src/lib/components/ui/Button/README.mdx
@@ -307,20 +307,20 @@ This is useful mainly to improve component's accessibility.
 The following theme options are common to all priorities and variants
 **except** the `link` priority (see [below for more](#link-priority)):
 
-| Custom Property               | Description                                  |
-|-------------------------------|----------------------------------------------|
-| `--rui-button-font-weight`    | Font weight                                  |
-| `--rui-button-text-transform` | Text transform, eg. uppercase or small-caps  |
-| `--rui-button-letter-spacing` | Spacing between letters                      |
-| `--rui-button-border-width`   | Border width                                 |
-| `--rui-button-border-radius`  | Corner radius                                |
+| Custom Property                | Description                                 |
+|--------------------------------|---------------------------------------------|
+| `--rui-Button__font-weight`    | Font weight                                 |
+| `--rui-Button__text-transform` | Text transform, eg. uppercase or small-caps |
+| `--rui-Button__letter-spacing` | Spacing between letters                     |
+| `--rui-Button__border-width`   | Border width                                |
+| `--rui-Button__border-radius`  | Corner radius                               |
 
 ### Theming Priorities and Variants
 
 It's possible to adjust the theme for specific priority, variant, and state.
 Naming convention looks as follows:
 
-`--rui-button-<PRIORITY>-<VARIANT>-<INTERACTION STATE>-<PROPERTY>`
+`--rui-Button--<PRIORITY>--<VARIANT>--<INTERACTION STATE>__<PROPERTY>`
 
 Where:
 
@@ -340,7 +340,8 @@ Where:
 
 The `link` priority is treated a bit different because from the theming point of
 view it doesn't share anything with other priorities. However, it shares
-everything with common links and thus can be adjusted using their theme options:
+everything with common links and thus can be adjusted by editing corresponding
+design tokens:
 
 | Custom Property               | Description                                  |
 |-------------------------------|----------------------------------------------|
@@ -353,7 +354,7 @@ everything with common links and thus can be adjusted using their theme options:
 
 Available sizes can be adjusted as follows:
 
-`--rui-button-<SIZE>-<PROPERTY>`
+`--rui-Button--<SIZE>__<PROPERTY>`
 
 Where:
 
@@ -367,14 +368,14 @@ Where:
   <style type="text/css">
     {`
       .example--themed-buttons {
-        --rui-button-font-weight: bold;
-        --rui-button-letter-spacing: 0.05em;
-        --rui-button-text-transform: uppercase;
-        --rui-button-border-radius: 0;
-        --rui-button-filled-primary-default-box-shadow:
+        --rui-Button__font-weight: bold;
+        --rui-Button__letter-spacing: 0.05em;
+        --rui-Button__text-transform: uppercase;
+        --rui-Button__border-radius: 0;
+        --rui-Button--filled--primary--default__box-shadow:
           0.1em 0.1em 0.5em rgba(0, 0, 0, 0.3);
-        --rui-button-medium-height: 3rem;
-        --rui-button-medium-padding-x: 1.25rem;
+        --rui-Button--medium__height: 3rem;
+        --rui-Button--medium__padding-x: 1.25rem;
       }
     `}
   </style>
@@ -391,15 +392,15 @@ Where:
 The `disabled` state offers a bit more of design flexibility compared to other
 interaction states. Firstly, there are a few common options for this state:
 
-| Custom Property                 | Description                                 |
-|---------------------------------|---------------------------------------------|
-| `--rui-button-disabled-opacity` | Opacity of disabled buttons                 |
-| `--rui-button-disabled-cursor`  | Cursor to show on hovering disabled buttons |
+| Custom Property                   | Description                                 |
+|-----------------------------------|---------------------------------------------|
+| `--rui-Button--disabled__opacity` | Opacity of disabled buttons                 |
+| `--rui-Button--disabled__cursor`  | Cursor to show on hovering disabled buttons |
 
 Secondly, it can be further adjusted using priority and variant specific
 options for the disabled state:
 
- `--rui-button-<PRIORITY>-<VARIANT>-disabled-<PROPERTY>`
+ `--rui-Button--<PRIORITY>--<VARIANT>--disabled__<PROPERTY>`
 
 Undefined theming options are inherited from the `default` interaction state.
 
@@ -409,17 +410,17 @@ Example:
   <style type="text/css">
     {`
       .example--themed-disabled-buttons {
-        --rui-button-border-radius: 0;
-        --rui-button-disabled-opacity: 0.4;
-        --rui-button-disabled-cursor: default;
-        --rui-button-filled-primary-disabled-color: slate;
-        --rui-button-filled-primary-disabled-border-color: silver;
-        --rui-button-filled-primary-disabled-background: silver;
-        --rui-button-filled-success-disabled-color: slate;
-        --rui-button-filled-success-disabled-border-color: silver;
-        --rui-button-filled-success-disabled-background: silver;
-        --rui-button-outline-primary-disabled-color: slate;
-        --rui-button-outline-primary-disabled-border-color: silver;
+        --rui-Button__border-radius: 0;
+        --rui-Button--disabled__opacity: 0.4;
+        --rui-Button--disabled__cursor: default;
+        --rui-Button--filled--primary--disabled__color: slate;
+        --rui-Button--filled--primary--disabled__border-color: silver;
+        --rui-Button--filled--primary--disabled__background: silver;
+        --rui-Button--filled--success--disabled__color: slate;
+        --rui-Button--filled--success--disabled__border-color: silver;
+        --rui-Button--filled--success--disabled__background: silver;
+        --rui-Button--outline--primary--disabled__color: slate;
+        --rui-Button--outline--primary--disabled__border-color: silver;
       }
     `}
   </style>

--- a/src/lib/components/ui/Button/_theme.scss
+++ b/src/lib/components/ui/Button/_theme.scss
@@ -1,23 +1,23 @@
 // Priority and variant specific theme options are obtained dynamically because there is way too
 // many of them to maintain manually. See `_tools.scss` for details.
 
-$font-weight: var(--rui-button-font-weight);
-$letter-spacing: var(--rui-button-letter-spacing);
-$text-transform: var(--rui-button-text-transform);
-$border-width: var(--rui-button-border-width);
-$border-radius: var(--rui-button-border-radius);
-$disabled-opacity: var(--rui-button-disabled-opacity);
-$disabled-cursor: var(--rui-button-disabled-cursor);
+$font-weight: var(--rui-Button__font-weight);
+$letter-spacing: var(--rui-Button__letter-spacing);
+$text-transform: var(--rui-Button__text-transform);
+$border-width: var(--rui-Button__border-width);
+$border-radius: var(--rui-Button__border-radius);
+$disabled-opacity: var(--rui-Button--disabled__opacity);
+$disabled-cursor: var(--rui-Button--disabled__cursor);
 
-$group-filled-gap: var(--rui-button-group-filled-gap);
-$group-filled-separator-width: var(--rui-button-group-filled-separator-width);
-$group-filled-separator-color: var(--rui-button-group-filled-separator-color);
+$group-filled-gap: var(--rui-ButtonGroup--filled__gap);
+$group-filled-separator-width: var(--rui-ButtonGroup--filled__separator__width);
+$group-filled-separator-color: var(--rui-ButtonGroup--filled__separator__color);
 
-$group-flat-gap: var(--rui-button-group-flat-gap);
-$group-flat-separator-width: var(--rui-button-group-flat-separator-width);
-$group-flat-separator-color: var(--rui-button-group-flat-separator-color);
+$group-flat-gap: var(--rui-ButtonGroup--flat__gap);
+$group-flat-separator-width: var(--rui-ButtonGroup--flat__separator__width);
+$group-flat-separator-color: var(--rui-ButtonGroup--flat__separator__color);
 
-$group-outline-gap: var(--rui-button-group-outline-gap);
+$group-outline-gap: var(--rui-ButtonGroup--outline__gap);
 
 $link-priority-properties: (
   default: (
@@ -32,18 +32,18 @@ $link-priority-properties: (
 
 $sizes: (
   small: (
-    height: var(--rui-button-small-height),
-    padding-x: var(--rui-button-small-padding-x),
-    font-size: var(--rui-button-small-font-size),
+    height: var(--rui-Button--small__height),
+    padding-x: var(--rui-Button--small__padding-x),
+    font-size: var(--rui-Button--small__font-size),
   ),
   medium: (
-    height: var(--rui-button-medium-height),
-    padding-x: var(--rui-button-medium-padding-x),
-    font-size: var(--rui-button-medium-font-size),
+    height: var(--rui-Button--medium__height),
+    padding-x: var(--rui-Button--medium__padding-x),
+    font-size: var(--rui-Button--medium__font-size),
   ),
   large: (
-    height: var(--rui-button-large-height),
-    padding-x: var(--rui-button-large-padding-x),
-    font-size: var(--rui-button-large-font-size),
+    height: var(--rui-Button--large__height),
+    padding-x: var(--rui-Button--large__padding-x),
+    font-size: var(--rui-Button--large__font-size),
   ),
 );

--- a/src/lib/components/ui/Button/_tools.scss
+++ b/src/lib/components/ui/Button/_tools.scss
@@ -50,15 +50,15 @@
     @each $property in $properties {
       --rui-local-#{$property}:
         var(
-          --rui-button-#{$priority}-#{$variant}-#{$state}-#{$property},
-          var(--rui-button-#{$priority}-#{$variant}-default-#{$property})
+          --rui-Button--#{$priority}--#{$variant}--#{$state}__#{$property},
+          var(--rui-Button--#{$priority}--#{$variant}--default__#{$property})
         );
     }
   }
 
   @else {
     @each $property in $properties {
-      --rui-local-#{$property}: var(--rui-button-#{$priority}-#{$variant}-#{$state}-#{$property});
+      --rui-local-#{$property}: var(--rui-Button--#{$priority}--#{$variant}--#{$state}__#{$property});
     }
   }
 }
@@ -160,12 +160,12 @@
 @mixin button-link() {
   @include _unset-button-appearance(); // 5.
 
-  text-decoration: map-get(map-get(theme.$link-priority-properties, default), text-decoration);
-  color: map-get(map-get(theme.$link-priority-properties, default), color);
+  text-decoration: map-get(theme.$link-priority-properties, default, text-decoration);
+  color: map-get(theme.$link-priority-properties, default, color);
 
   &:not(:disabled):hover,
   &:not(:disabled):focus {
-    text-decoration: map-get(map-get(theme.$link-priority-properties, hover), text-decoration);
-    color: map-get(map-get(theme.$link-priority-properties, hover), color);
+    text-decoration: map-get(theme.$link-priority-properties, hover, text-decoration);
+    color: map-get(theme.$link-priority-properties, hover, color);
   }
 }

--- a/src/lib/components/ui/ButtonGroup/README.mdx
+++ b/src/lib/components/ui/ButtonGroup/README.mdx
@@ -213,10 +213,10 @@ and communicating the state of individual options.
 
 | Custom Property                                                    | Description                                    |
 |--------------------------------------------------------------------|------------------------------------------------|
-| `--rui-button-group-filled-gap`                                    | Gap between `filled` buttons                   |
-| `--rui-button-group-filled-separator-width`                        | Separator width for `filled` buttons           |
-| `--rui-button-group-filled-separator-color`                        | Separator color for `filled` buttons           |
-| `--rui-button-group-flat-gap`                                      | Gap between `flat` buttons                     |
-| `--rui-button-group-flat-separator-width`                          | Separator width for `flat` buttons             |
-| `--rui-button-group-flat-separator-color`                          | Separator color for `flat` buttons             |
-| `--rui-button-group-outline-gap`                                   | Gap between `outline` buttons                  |
+| `--rui-ButtonGroup--filled__gap`                                   | Gap between `filled` buttons                   |
+| `--rui-ButtonGroup--filled__separator__width`                      | Separator width for `filled` buttons           |
+| `--rui-ButtonGroup--filled__separator__color`                      | Separator color for `filled` buttons           |
+| `--rui-ButtonGroup--flat__gap`                                     | Gap between `flat` buttons                     |
+| `--rui-ButtonGroup--flat__separator__width`                        | Separator width for `flat` buttons             |
+| `--rui-ButtonGroup--flat__separator__color`                        | Separator color for `flat` buttons             |
+| `--rui-ButtonGroup--outline__gap`                                  | Gap between `outline` buttons                  |

--- a/src/lib/components/ui/Card/README.mdx
+++ b/src/lib/components/ui/Card/README.mdx
@@ -288,3 +288,32 @@ Separate your card actions with CardFooter. See
 [Card Composition](#card-composition) for all details.
 
 <Props table of={CardFooter} />
+
+## Theming
+
+### Common Theming Options
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Card__padding`                                | Padding shared by card header, body and footer               |
+| `--rui-Card__border-width`                           | Border width                                                 |
+| `--rui-Card__border-radius`                          | Corner radius                                                |
+| `--rui-Card__background-color`                       | Card background color                                        |
+| `--rui-Card--dense__padding`                         | Padding of dense card                                        |
+| `--rui-Card--flat__border-color`                     | Border color of flat card variant                            |
+| `--rui-Card--bordered__border-color`                 | Border color of bordered card variant                        |
+| `--rui-Card--raised__box-shadow`                     | Box shadow of raised card                                    |
+| `--rui-Card--disabled__background-color`             | Card background color in disabled state                      |
+| `--rui-Card--disabled__opacity`                      | Card opacity in disabled state                               |
+
+### Theming Types
+
+It's possible to adjust the theme of specific card type. Naming convention
+looks as follows:
+
+`--rui-Card--<TYPE>__border-color`
+
+Where:
+
+- `<TYPE>` is one of `success`, `warning`, `error`, `info`, `note`, or `help`
+  (see [card types](#card-types) and [API](#api))

--- a/src/lib/components/ui/Card/_theme.scss
+++ b/src/lib/components/ui/Card/_theme.scss
@@ -1,44 +1,44 @@
-$padding: var(--rui-card-padding);
-$dense-padding: var(--rui-card-dense-padding);
-$background-color: var(--rui-card-background-color);
-$border-width: var(--rui-card-border-width);
-$border-radius: var(--rui-card-border-radius);
+$padding: var(--rui-Card__padding);
+$border-width: var(--rui-Card__border-width);
+$border-radius: var(--rui-Card__border-radius);
+$background-color: var(--rui-Card__background-color);
+$dense-padding: var(--rui-Card--dense__padding);
 
 $types: (
   success: (
-    border-color: var(--rui-card-success-border-color),
+    border-color: var(--rui-Card--success__border-color),
   ),
   warning: (
-    border-color: var(--rui-card-warning-border-color),
+    border-color: var(--rui-Card--warning__border-color),
   ),
   error: (
-    border-color: var(--rui-card-error-border-color),
+    border-color: var(--rui-Card--error__border-color),
   ),
   help: (
-    border-color: var(--rui-card-help-border-color),
+    border-color: var(--rui-Card--help__border-color),
   ),
   info: (
-    border-color: var(--rui-card-info-border-color),
+    border-color: var(--rui-Card--info__border-color),
   ),
   note: (
-    border-color: var(--rui-card-note-border-color),
+    border-color: var(--rui-Card--note__border-color),
   ),
 );
 
 $variants: (
   flat: (
-    border-color: var(--rui-card-flat-border-color),
+    border-color: var(--rui-Card--flat__border-color),
   ),
   bordered: (
-    border-color: var(--rui-card-bordered-border-color),
+    border-color: var(--rui-Card--bordered__border-color),
   ),
 );
 
 $disabled: (
-  background-color: var(--rui-card-disabled-background-color),
-  opacity: var(--rui-card-disabled-opacity),
+  background-color: var(--rui-Card--disabled__background-color),
+  opacity: var(--rui-Card--disabled__opacity),
 );
 
 $raised: (
-  box-shadow: var(--rui-card-raised-box-shadow),
+  box-shadow: var(--rui-Card--raised__box-shadow),
 );

--- a/src/lib/components/ui/CheckboxField/README.mdx
+++ b/src/lib/components/ui/CheckboxField/README.mdx
@@ -203,7 +203,7 @@ This is useful mainly to improve component's accessibility.
 Head to [Forms Theming](/customize/theming/forms) to see shared form theming
 options. On top of that, the following options are available for CheckboxField.
 
-| Custom Property                                                    | Description                                    |
-|--------------------------------------------------------------------|------------------------------------------------|
-| `--rui-form-field-check-input-checkbox-border-radius`              | Input border radius                            |
-| `--rui-form-field-check-input-checkbox-checked-background-image`  | Checked input background image (inline, URL, …) |
+| Custom Property                                                      | Description                                  |
+|----------------------------------------------------------------------|----------------------------------------------|
+| `--rui-FormField--check__input--checkbox__border-radius`             | Input corner radius                          |
+| `--rui-FormField--check__input--checkbox--checked__background-image` | Background image of checked input            |

--- a/src/lib/components/ui/Modal/Modal.jsx
+++ b/src/lib/components/ui/Modal/Modal.jsx
@@ -144,7 +144,7 @@ export class Modal extends React.Component {
 
     return (
       <div
-        className={styles.overlay}
+        className={styles.backdrop}
         id={id}
         onClick={(e) => {
           if (closeHandler) {

--- a/src/lib/components/ui/Modal/Modal.scss
+++ b/src/lib/components/ui/Modal/Modal.scss
@@ -7,23 +7,23 @@
 @use 'theme';
 
 .root {
-  --local-outer-offset: #{theme.$outer-offset-xs};
+  --local-outer-spacing: #{theme.$outer-spacing-xs};
 
   position: fixed;
   left: 50%;
   z-index: settings.$z-index;
   display: flex;
   flex-direction: column;
-  max-width: calc(100% - (2 * var(--local-outer-offset)));
-  max-height: calc(100% - (2 * var(--local-outer-offset)));
+  max-width: calc(100% - (2 * var(--local-outer-spacing)));
+  max-height: calc(100% - (2 * var(--local-outer-spacing)));
   overflow-y: auto;
   border-radius: settings.$border-radius;
-  background-color: theme.$background;
+  background: theme.$background;
   box-shadow: theme.$box-shadow;
   transform: translateX(-50%);
 
   @include breakpoint.up(sm) {
-    --local-outer-offset: #{theme.$outer-offset-sm};
+    --local-outer-spacing: #{theme.$outer-spacing-sm};
   }
 }
 
@@ -75,34 +75,34 @@
   padding: settings.$padding-y settings.$padding-x;
   border-bottom-right-radius: settings.$border-radius;
   border-bottom-left-radius: settings.$border-radius;
-  background-color: theme.$footer-background;
+  background: theme.$footer-background;
 }
 
-.overlay {
+.backdrop {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: settings.$overlay-z-index;
+  z-index: settings.$backdrop-z-index;
   width: 100vw;
   height: 100vh;
-  background-color: theme.$overlay-background;
+  background: theme.$backdrop-background;
 }
 
 .isRootSizeSmall {
-  width: theme.$size-small-width;
+  width: map-get(theme.$sizes, small, width);
 }
 
 .isRootSizeMedium {
-  width: theme.$size-medium-width;
+  width: map-get(theme.$sizes, medium, width);
 }
 
 .isRootSizeLarge {
-  width: theme.$size-large-width;
+  width: map-get(theme.$sizes, large, width);
 }
 
 .isRootSizeFullscreen {
-  width: theme.$size-fullscreen-width;
-  height: theme.$size-fullscreen-height;
+  width: map-get(theme.$sizes, fullscreen, width);
+  height: map-get(theme.$sizes, fullscreen, height);
 }
 
 .isRootSizeFullscreen .content {
@@ -111,8 +111,8 @@
 
 .isRootSizeAuto {
   width: auto;
-  min-width: theme.$size-auto-min-width;
-  max-width: theme.$size-auto-max-width;
+  min-width: map-get(theme.$sizes, auto, min-width);
+  max-width: map-get(theme.$sizes, auto, max-width);
 }
 
 .isRootPositionCenter {
@@ -121,5 +121,5 @@
 }
 
 .isRootPositionTop {
-  top: var(--local-outer-offset);
+  top: var(--local-outer-spacing);
 }

--- a/src/lib/components/ui/Modal/README.mdx
+++ b/src/lib/components/ui/Modal/README.mdx
@@ -408,3 +408,21 @@ to prevent interaction. That's where blocking modals may come handy.
 ## API
 
 <Props table of={ParsableModal} />
+
+## Theming
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Modal__background`                            | Modal background (including `url()` or gradient)             |
+| `--rui-Modal__box-shadow`                            | Modal box shadow                                             |
+| `--rui-Modal__outer-spacing-xs`                      | Spacing around modal, `xs` screen size                       |
+| `--rui-Modal__outer-spacing-sm`                      | Spacing around modal, `sm` screen size and bigger            |
+| `--rui-Modal__footer__background`                    | Modal footer background (including `url()` or gradient)      |
+| `--rui-Modal__backdrop__background`                  | Modal backdrop background (including `url()` or gradient)    |
+| `--rui-Modal--auto__min-width`                       | Minimum width of auto-sized modal                            |
+| `--rui-Modal--auto__max-width`                       | Maximum width of auto-sized modal                            |
+| `--rui-Modal--small__width`                          | Width of small modal                                         |
+| `--rui-Modal--medium__width`                         | Width of medium modal                                        |
+| `--rui-Modal--large__width`                          | Width of large modal                                         |
+| `--rui-Modal--fullscreen__width`                     | Width of fullscreen modal                                    |
+| `--rui-Modal--fullscreen__height`                    | Height of fullscreen modal                                   |

--- a/src/lib/components/ui/Modal/__tests__/__snapshots__/Modal.test.jsx.snap
+++ b/src/lib/components/ui/Modal/__tests__/__snapshots__/Modal.test.jsx.snap
@@ -64,7 +64,7 @@ exports[`rendering renders correctly with all props except loading icon 1`] = `
     }
   >
     <div
-      className="overlay"
+      className="backdrop"
       id="custom-id"
       onClick={[Function]}
       role="presentation"
@@ -392,7 +392,7 @@ exports[`rendering renders correctly with mandatory props only 1`] = `
     }
   >
     <div
-      className="overlay"
+      className="backdrop"
       onClick={[Function]}
       role="presentation"
     >
@@ -547,7 +547,7 @@ exports[`rendering renders correctly with portal id 1`] = `
           id="app-modal-portal"
         >
           <div
-            class="overlay"
+            class="backdrop"
             role="presentation"
           >
             <div
@@ -595,7 +595,7 @@ exports[`rendering renders correctly with portal id 1`] = `
       }
     >
       <div
-        className="overlay"
+        className="backdrop"
         onClick={[Function]}
         role="presentation"
       >
@@ -746,7 +746,7 @@ exports[`rendering renders correctly with translations 1`] = `
     }
   >
     <div
-      className="overlay"
+      className="backdrop"
       onClick={[Function]}
       role="presentation"
     >

--- a/src/lib/components/ui/Modal/_settings.scss
+++ b/src/lib/components/ui/Modal/_settings.scss
@@ -9,4 +9,4 @@ $content-padding-bottom: spacing.of(6);
 $border-radius: borders.$radius;
 $head-title-font-size: map-get(typography.$size-values, 1);
 $z-index: z-indexes.$modal;
-$overlay-z-index: z-indexes.$modal-overlay;
+$backdrop-z-index: z-indexes.$modal-backdrop;

--- a/src/lib/components/ui/Modal/_theme.scss
+++ b/src/lib/components/ui/Modal/_theme.scss
@@ -1,13 +1,26 @@
-$background: var(--rui-modal-background);
-$box-shadow: var(--rui-modal-box-shadow);
-$footer-background: var(--rui-modal-footer-background);
-$overlay-background: var(--rui-modal-overlay-background);
-$size-auto-min-width: var(--rui-modal-size-auto-min-width);
-$size-auto-max-width: var(--rui-modal-size-auto-max-width);
-$size-small-width: var(--rui-modal-size-small-width);
-$size-medium-width: var(--rui-modal-size-medium-width);
-$size-large-width: var(--rui-modal-size-large-width);
-$size-fullscreen-height: var(--rui-modal-size-fullscreen-height);
-$size-fullscreen-width: var(--rui-modal-size-fullscreen-width);
-$outer-offset-xs: var(--rui-modal-outer-offset-xs);
-$outer-offset-sm: var(--rui-modal-outer-offset-sm);
+$background: var(--rui-Modal__background);
+$box-shadow: var(--rui-Modal__box-shadow);
+$footer-background: var(--rui-Modal__footer__background);
+$backdrop-background: var(--rui-Modal__backdrop__background);
+$outer-spacing-xs: var(--rui-Modal__outer-spacing--xs);
+$outer-spacing-sm: var(--rui-Modal__outer-spacing--sm);
+
+$sizes: (
+  auto: (
+    min-width: var(--rui-Modal--auto__min-width),
+    max-width: var(--rui-Modal--auto__max-width),
+  ),
+  small: (
+    width: var(--rui-Modal--small__width),
+  ),
+  medium: (
+    width: var(--rui-Modal--medium__width),
+  ),
+  large: (
+    width: var(--rui-Modal--large__width),
+  ),
+  fullscreen: (
+    width: var(--rui-Modal--fullscreen__width),
+    height: var(--rui-Modal--fullscreen__height),
+  ),
+);

--- a/src/lib/components/ui/Radio/README.mdx
+++ b/src/lib/components/ui/Radio/README.mdx
@@ -307,5 +307,5 @@ options. On top of that, the following options are available for Radio.
 
 | Custom Property                                                    | Description                                    |
 |--------------------------------------------------------------------|------------------------------------------------|
-| `--rui-form-field-check-input-radio-border-radius`                 | Input border radius                            |
-| `--rui-form-field-check-input-radio-checked-background-image`     | Checked input background image (inline, URL, …) |
+| `--rui-FormField--check__input--radio__border-radius`              | Input corner radius                            |
+| `--rui-FormField--check__input--radio--checked__background-image` | Checked input background image (inline, URL, …) |

--- a/src/lib/components/ui/ScrollView/README.mdx
+++ b/src/lib/components/ui/ScrollView/README.mdx
@@ -433,3 +433,10 @@ we use in the [Modal](/components/ui/modal#scrolling-long-content) component.
 ## API
 
 <Props table of={ParsableScrollView} />
+
+## Theming
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-ScrollView__arrow__initial-offset`            | Initial offset of scrolling arrows (transitioned)            |
+| `--rui-ScrollView__shadow__initial-offset`           | Initial offset of scrolling shadows (transitioned)           |

--- a/src/lib/components/ui/ScrollView/_theme.scss
+++ b/src/lib/components/ui/ScrollView/_theme.scss
@@ -1,2 +1,2 @@
-$arrow-initial-offset: var(--rui-scrollview-arrow-initial-offset);
-$shadow-initial-offset: var(--rui-scrollview-shadow-initial-offset);
+$arrow-initial-offset: var(--rui-ScrollView__arrow__initial-offset);
+$shadow-initial-offset: var(--rui-ScrollView__shadow__initial-offset);

--- a/src/lib/components/ui/SelectField/README.mdx
+++ b/src/lib/components/ui/SelectField/README.mdx
@@ -644,6 +644,6 @@ options. On top of that, the following options are available for SelectField.
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-form-field-box-select-caret-border-style`     | SelectField arrow border style (eg. solid)                   |
-| `--rui-form-field-box-select-caret-background`       | SelectField arrow background                                 |
-| `--rui-form-field-box-select-option-disabled-color`  | Text color of disabled SelectField options                   |
+| `--rui-FormField--box--select__caret__border-style`  | SelectField arrow border style (eg. `solid`)                 |
+| `--rui-FormField--box--select__caret__background`    | SelectField arrow background (including `url()` or gradient) |
+| `--rui-FormField--box--select__option--disabled__color` | Text color of disabled SelectField options                |

--- a/src/lib/components/ui/Toggle/README.mdx
+++ b/src/lib/components/ui/Toggle/README.mdx
@@ -200,10 +200,10 @@ options. On top of that, the following options are available for Toggle.
 
 | Custom Property                                                    | Description                                    |
 |--------------------------------------------------------------------|------------------------------------------------|
-| `--rui-form-field-check-input-toggle-width`                | Input width (height is shared with other check fields) |
-| `--rui-form-field-check-input-toggle-border-radius`                | Input border radius                            |
-| `--rui-form-field-check-input-toggle-background-size`              | Input background size                          |
-| `--rui-form-field-check-input-toggle-default-background-image`     | Background image of unchecked input            |
-| `--rui-form-field-check-input-toggle-default-background-position`  | Background position of unchecked input         |
-| `--rui-form-field-check-input-toggle-checked-background-image`     | Background image of checked input              |
-| `--rui-form-field-check-input-toggle-checked-background-position`  | Background position of checked input           |
+| `--rui-FormField--check__input--toggle__width`             | Input width (height is shared with other check fields) |
+| `--rui-FormField--check__input--toggle__border-radius`             | Input corner radius                            |
+| `--rui-FormField--check__input--toggle__background-size`           | Input background size                          |
+| `--rui-FormField--check__input--toggle--default__background-image` | Background image of unchecked input            |
+| `--rui-FormField--check__input--toggle--default__background-position` | Background position of unchecked input      |
+| `--rui-FormField--check__input--toggle--checked__background-image` | Background image of checked input              |
+| `--rui-FormField--check__input--toggle--checked__background-position` | Background position of checked input        |

--- a/src/lib/provider/__tests__/__snapshots__/RUIProvider.test.jsx.snap
+++ b/src/lib/provider/__tests__/__snapshots__/RUIProvider.test.jsx.snap
@@ -52,7 +52,7 @@ exports[`rendering renders component with default provider 1`] = `
       }
     >
       <div
-        className="overlay"
+        className="backdrop"
         onClick={[Function]}
         role="presentation"
       >
@@ -301,7 +301,7 @@ exports[`rendering renders component with provided both translations and global 
       }
     >
       <div
-        className="overlay"
+        className="backdrop"
         onClick={[Function]}
         role="presentation"
       >
@@ -553,7 +553,7 @@ exports[`rendering renders component with provided global props 1`] = `
       }
     >
       <div
-        className="overlay"
+        className="backdrop"
         onClick={[Function]}
         role="presentation"
       >
@@ -796,7 +796,7 @@ exports[`rendering renders component with provided translations 1`] = `
       }
     >
       <div
-        className="overlay"
+        className="backdrop"
         onClick={[Function]}
         role="presentation"
       >
@@ -1025,7 +1025,7 @@ exports[`rendering renders component without provider 1`] = `
     }
   >
     <div
-      className="overlay"
+      className="backdrop"
       onClick={[Function]}
       role="presentation"
     >

--- a/src/lib/styles/settings/_z-indexes.scss
+++ b/src/lib/styles/settings/_z-indexes.scss
@@ -1,2 +1,2 @@
-$modal-overlay: 2000;
+$modal-backdrop: 2000;
 $modal: 2100;

--- a/src/lib/styles/theme/_form-fields.scss
+++ b/src/lib/styles/theme/_form-fields.scss
@@ -2,92 +2,92 @@
 // maintain manually. See `settings/_form-fields.scss` and `tools/form-fields/_variants.scss` for
 // details.
 //
-// 1. Defaults to zero when neither `--rui-form-field-horizontal-label-padding-y` (optional) nor
+// 1. Defaults to zero when neither `--rui-FormField--horizontal__label__padding-y` (optional) nor
 //    `--rui-local-padding-y` (handled by the `size()` mixin in case of box form fields, see
 //    `_box-field-sizes.scss`) is defined. This is useful because FormLayoutCustomField may have no
 //    size specified therefore its label should have no padding at the top.
 
 // Forms fields: common properties
-$label-color: var(--rui-form-field-label-color);
-$label-font-size: var(--rui-form-field-label-font-size);
-$help-text-font-size: var(--rui-form-field-help-text-font-size);
-$help-text-font-style: var(--rui-form-field-help-text-font-style);
-$help-text-color: var(--rui-form-field-help-text-color);
-$required-sign: var(--rui-form-field-required-sign);
-$required-sign-color: var(--rui-form-field-required-sign-color);
+$label-color: var(--rui-FormField__label__color);
+$label-font-size: var(--rui-FormField__label__font-size);
+$help-text-font-size: var(--rui-FormField__help-text__font-size);
+$help-text-font-style: var(--rui-FormField__help-text__font-style);
+$help-text-color: var(--rui-FormField__help-text__color);
+$required-sign: var(--rui-FormField--required__sign);
+$required-sign-color: var(--rui-FormField--required__sign__color);
 
 // Form fields: horizontal layout
-$horizontal-label-text-align: var(--rui-form-field-horizontal-label-text-align);
-$horizontal-label-min-width: var(--rui-form-field-horizontal-label-min-width);
-$horizontal-label-width: var(--rui-form-field-horizontal-label-width);
+$horizontal-label-text-align: var(--rui-FormField--horizontal__label__text-align);
+$horizontal-label-min-width: var(--rui-FormField--horizontal__label__min-width);
+$horizontal-label-width: var(--rui-FormField--horizontal__label__width);
 $horizontal-label-padding-y:
   var(
-    --rui-form-field-horizontal-label-padding-y,
-    calc(var(--rui-form-field-box-border-width) + var(--rui-local-padding-y))
+    --rui-FormField--horizontal__label__padding-y,
+    calc(var(--rui-FormField--box__border-width) + var(--rui-local-padding-y))
   ); // 1.
-$horizontal-label-vertical-alignment: var(--rui-form-field-horizontal-label-vertical-alignment);
-$horizontal-field-vertical-alignment: var(--rui-form-field-horizontal-field-vertical-alignment);
-$horizontal-full-width-label-width: var(--rui-form-field-horizontal-full-width-label-width);
+$horizontal-label-vertical-alignment: var(--rui-FormField--horizontal__label__vertical-alignment);
+$horizontal-field-vertical-alignment: var(--rui-FormField--horizontal__field__vertical-alignment);
+$horizontal-full-width-label-width: var(--rui-FormField--horizontal--full-width__label__width);
 
 // Form fields: disabled state
-$disabled-cursor: var(--rui-form-field-disabled-cursor);
-$disabled-opacity: var(--rui-form-field-disabled-opacity);
+$disabled-cursor: var(--rui-FormField--disabled__cursor);
+$disabled-opacity: var(--rui-FormField--disabled__opacity);
 
 // Form fields: box fields
-$box-input-width: var(--rui-form-field-box-input-width);
-$box-input-min-width: var(--rui-form-field-box-input-min-width);
-$box-border-width: var(--rui-form-field-box-border-width);
-$box-border-radius: var(--rui-form-field-box-border-radius);
-$box-placeholder-color: var(--rui-form-field-box-placeholder-color);
+$box-border-width: var(--rui-FormField--box__border-width);
+$box-border-radius: var(--rui-FormField--box__border-radius);
+$box-input-width: var(--rui-FormField--box__input__width);
+$box-input-min-width: var(--rui-FormField--box__input__min-width);
+$box-placeholder-color: var(--rui-FormField--box__placeholder__color);
 
 // Form fields: box fields, component specific
-$box-select-caret-border-style: var(--rui-form-field-box-select-caret-border-style);
-$box-select-caret-background: var(--rui-form-field-box-select-caret-background);
-$box-select-option-disabled-color: var(--rui-form-field-box-select-option-disabled-color);
+$box-select-caret-border-style: var(--rui-FormField--box--select__caret__border-style);
+$box-select-caret-background: var(--rui-FormField--box--select__caret__background);
+$box-select-option-disabled-color: var(--rui-FormField--box--select__option--disabled__color);
 
 // Form fields: box field sizes
 $box-sizes: (
   small: (
-    height: var(--rui-form-field-box-small-height),
-    padding-y: var(--rui-form-field-box-small-padding-y),
-    padding-x: var(--rui-form-field-box-small-padding-x),
-    font-size: var(--rui-form-field-box-small-font-size),
+    height: var(--rui-FormField--box--small__height),
+    padding-y: var(--rui-FormField--box--small__padding-y),
+    padding-x: var(--rui-FormField--box--small__padding-x),
+    font-size: var(--rui-FormField--box--small__font-size),
   ),
   medium: (
-    height: var(--rui-form-field-box-medium-height),
-    padding-y: var(--rui-form-field-box-medium-padding-y),
-    padding-x: var(--rui-form-field-box-medium-padding-x),
-    font-size: var(--rui-form-field-box-medium-font-size),
+    height: var(--rui-FormField--box--medium__height),
+    padding-y: var(--rui-FormField--box--medium__padding-y),
+    padding-x: var(--rui-FormField--box--medium__padding-x),
+    font-size: var(--rui-FormField--box--medium__font-size),
   ),
   large: (
-    height: var(--rui-form-field-box-large-height),
-    padding-y: var(--rui-form-field-box-large-padding-y),
-    padding-x: var(--rui-form-field-box-large-padding-x),
-    font-size: var(--rui-form-field-box-large-font-size),
+    height: var(--rui-FormField--box--large__height),
+    padding-y: var(--rui-FormField--box--large__padding-y),
+    padding-x: var(--rui-FormField--box--large__padding-x),
+    font-size: var(--rui-FormField--box--large__font-size),
   ),
 );
 
 // Form fields: check fields
-$check-input-size: var(--rui-form-field-check-input-size);
-$check-input-border-width: var(--rui-form-field-check-input-border-width);
-$check-input-focus-box-shadow: var(--rui-form-field-check-input-focus-box-shadow);
-$check-tap-target-size: var(--rui-form-field-check-tap-target-size);
+$check-input-size: var(--rui-FormField--check__input__size);
+$check-input-border-width: var(--rui-FormField--check__input__border-width);
+$check-input-focus-box-shadow: var(--rui-FormField--check__input--focus__box-shadow);
+$check-tap-target-size: var(--rui-FormField--check__tap-target-size);
 
 // Form fields: check fields, component specific
-$check-input-checkbox-border-radius: var(--rui-form-field-check-input-checkbox-border-radius);
+$check-input-checkbox-border-radius: var(--rui-FormField--check__input--checkbox__border-radius);
 $check-input-checkbox-checked-background-image:
-  var(--rui-form-field-check-input-checkbox-checked-background-image);
-$check-input-radio-border-radius: var(--rui-form-field-check-input-radio-border-radius);
+  var(--rui-FormField--check__input--checkbox--checked__background-image);
+$check-input-radio-border-radius: var(--rui-FormField--check__input--radio__border-radius);
 $check-input-radio-checked-background-image:
-  var(--rui-form-field-check-input-radio-checked-background-image);
-$check-input-toggle-width: var(--rui-form-field-check-input-toggle-width);
-$check-input-toggle-border-radius: var(--rui-form-field-check-input-toggle-border-radius);
-$check-input-toggle-background-size: var(--rui-form-field-check-input-toggle-background-size);
+  var(--rui-FormField--check__input--radio--checked__background-image);
+$check-input-toggle-width: var(--rui-FormField--check__input--toggle__width);
+$check-input-toggle-border-radius: var(--rui-FormField--check__input--toggle__border-radius);
+$check-input-toggle-background-size: var(--rui-FormField--check__input--toggle__background-size);
 $check-input-toggle-default-background-image:
-  var(--rui-form-field-check-input-toggle-default-background-image);
+  var(--rui-FormField--check__input--toggle--default__background-image);
 $check-input-toggle-default-background-position:
-  var(--rui-form-field-check-input-toggle-default-background-position);
+  var(--rui-FormField--check__input--toggle--default__background-position);
 $check-input-toggle-checked-background-image:
-  var(--rui-form-field-check-input-toggle-checked-background-image);
+  var(--rui-FormField--check__input--toggle--checked__background-image);
 $check-input-toggle-checked-background-position:
-  var(--rui-form-field-check-input-toggle-checked-background-position);
+  var(--rui-FormField--check__input--toggle--checked__background-position);

--- a/src/lib/styles/tools/form-fields/_variants.scss
+++ b/src/lib/styles/tools/form-fields/_variants.scss
@@ -38,7 +38,7 @@
   }
 
   @if ($type != 'validation' and $variant != 'default') {
-    $infix: #{$type}-#{$variant};
+    $infix: #{$type}--#{$variant};
   }
 
   @if ($state == 'checked-disabled') {
@@ -47,7 +47,7 @@
 
   @if ($state == 'default') {
     @each $property in $properties {
-      --rui-local-#{$property}: var(--rui-form-field-#{$infix}-#{$state}-#{$property});
+      --rui-local-#{$property}: var(--rui-FormField--#{$infix}--#{$state}__#{$property});
     }
   }
 
@@ -56,8 +56,8 @@
     @each $property in $properties {
       --rui-local-#{$property}:
         var(
-          --rui-form-field-#{$infix}-#{$state}-#{$property},
-          var(--rui-form-field-#{$infix}-#{$fallback-state}-#{$property})
+          --rui-FormField--#{$infix}--#{$state}__#{$property},
+          var(--rui-FormField--#{$infix}--#{$fallback-state}__#{$property})
         );
     }
   }
@@ -134,7 +134,7 @@
   @if ($type == 'box' and $variant == 'outline' and $has-caret) {
     .caret {
       border-left: theme.$box-border-width theme.$box-select-caret-border-style var(--rui-local-border-color);
-      background-color: theme.$box-select-caret-background;
+      background: theme.$box-select-caret-background;
     }
 
     &.isRootDisabled .caret {

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -5,6 +5,10 @@
 
 :root {
 
+  // ============================================================================================ //
+  // 1. DESIGN TOKENS                                                                             //
+  // ============================================================================================ //
+
   //
   // Colors
   // ======
@@ -102,6 +106,29 @@
   --rui-spacing-7: 3rem;
 
   //
+  // Typography
+  // ==========
+
+  // Modular scale ratio: 1.125 / 8:9 / major second
+
+  --rui-typography-font-family-base: 'Titillium Web', helvetica, roboto, arial, sans-serif;
+  --rui-typography-font-size-base: 100%;
+  --rui-typography-line-height-base: 1.5;
+  --rui-typography-size-0: 1rem;
+  --rui-typography-size-1: 1.125rem;
+  --rui-typography-size-2: 1.266rem;
+  --rui-typography-size-3: 1.424rem;
+  --rui-typography-size-4: 1.602rem;
+  --rui-typography-size-5: 1.802rem;
+  --rui-typography-size-smaller: 0.75rem;
+  --rui-typography-size-small: 0.889rem;
+  --rui-typography-font-weight-thin: 100;
+  --rui-typography-font-weight-light: 300;
+  --rui-typography-font-weight-regular: 400;
+  --rui-typography-font-weight-medium: 500;
+  --rui-typography-font-weight-bold: 700;
+
+  //
   // Shared Settings
   // ===============
 
@@ -139,351 +166,372 @@
   --rui-code-font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   --rui-code-font-size: 85%;
 
+  // ============================================================================================ //
+  // 2. LAYOUT COMPONENTS                                                                         //
+  // ============================================================================================ //
+
   //
-  // Typography
+  // FormLayout
   // ==========
 
-  // Modular scale ratio: 1.125 / 8:9 / major second
+  --rui-FormLayout__row-gap: var(--rui-spacing-4);
+  --rui-FormLayout--horizontal__label__width: 10em;
+  --rui-FormLayout--horizontal__label__width--auto: auto;
+  --rui-FormLayout--horizontal__label__width--limited: fit-content(50%);
 
-  --rui-typography-font-family-base: 'Titillium Web', helvetica, roboto, arial, sans-serif;
-  --rui-typography-font-size-base: 100%;
-  --rui-typography-font-weight-thin: 100;
-  --rui-typography-font-weight-light: 300;
-  --rui-typography-font-weight-regular: 400;
-  --rui-typography-font-weight-medium: 500;
-  --rui-typography-font-weight-bold: 700;
-  --rui-typography-line-height-base: 1.5;
-  --rui-typography-size-smaller: 0.75rem;
-  --rui-typography-size-small: 0.889rem;
-  --rui-typography-size-0: 1rem;
-  --rui-typography-size-1: 1.125rem;
-  --rui-typography-size-2: 1.266rem;
-  --rui-typography-size-3: 1.424rem;
-  --rui-typography-size-4: 1.602rem;
-  --rui-typography-size-5: 1.802rem;
+  //
+  // Grid
+  // ====
+
+  --rui-Grid__auto-flow: initial;
+  --rui-Grid__columns: 1fr;
+  --rui-Grid__column-gap: var(--rui-spacing-4);
+  --rui-Grid__rows: auto;
+  --rui-Grid__row-gap: var(--rui-spacing-4);
+  --rui-Grid__align-content: initial;
+  --rui-Grid__align-items: initial;
+  --rui-Grid__justify-content: initial;
+  --rui-Grid__justify-items: initial;
+
+  //
+  // List
+  // ====
+
+  --rui-List__row-gap: var(--rui-spacing-2);
+
+  //
+  // Toolbar
+  // =======
+
+  --rui-Toolbar__gap: var(--rui-spacing-2);
+  --rui-Toolbar__gap--dense: var(--rui-spacing-1);
+
+  // ============================================================================================ //
+  // 3. UI COMPONENTS                                                                             //
+  // ============================================================================================ //
 
   //
   // Alerts
   // =======
 
   // Alerts: common properties
-  --rui-alert-font-weight: var(--rui-typography-font-weight-regular);
-  --rui-alert-emphasis-font-weight: var(--rui-typography-font-weight-bold);
-  --rui-alert-border-width: var(--rui-border-width);
-  --rui-alert-border-radius: var(--rui-border-radius);
-  --rui-alert-stripe-width: var(--rui-border-width);
-  --rui-alert-padding: var(--rui-spacing-3);
+  --rui-Alert__padding: var(--rui-spacing-3);
+  --rui-Alert__font-weight: var(--rui-typography-font-weight-regular);
+  --rui-Alert__border-width: var(--rui-border-width);
+  --rui-Alert__border-radius: var(--rui-border-radius);
+  --rui-Alert__emphasis__font-weight: var(--rui-typography-font-weight-bold);
+  --rui-Alert__stripe__width: var(--rui-border-width);
 
   // Alerts: type: success
-  --rui-alert-success-foreground-color: var(--rui-color-success);
-  --rui-alert-success-background-color: var(--rui-color-white);
-  --rui-alert-success-text-color: var(--rui-page-color);
+  --rui-Alert--success__foreground-color: var(--rui-color-success);
+  --rui-Alert--success__background-color: var(--rui-color-white);
+  --rui-Alert--success__text-color: var(--rui-page-color);
 
   // Alerts: type: warning
-  --rui-alert-warning-foreground-color: var(--rui-color-warning);
-  --rui-alert-warning-background-color: var(--rui-color-white);
-  --rui-alert-warning-text-color: var(--rui-page-color);
+  --rui-Alert--warning__foreground-color: var(--rui-color-warning);
+  --rui-Alert--warning__background-color: var(--rui-color-white);
+  --rui-Alert--warning__text-color: var(--rui-page-color);
 
   // Alerts: type: error
-  --rui-alert-error-foreground-color: var(--rui-color-error);
-  --rui-alert-error-background-color: var(--rui-color-white);
-  --rui-alert-error-text-color: var(--rui-page-color);
+  --rui-Alert--error__foreground-color: var(--rui-color-error);
+  --rui-Alert--error__background-color: var(--rui-color-white);
+  --rui-Alert--error__text-color: var(--rui-page-color);
 
   // Alerts: type: info
-  --rui-alert-info-foreground-color: var(--rui-color-info);
-  --rui-alert-info-background-color: var(--rui-color-white);
-  --rui-alert-info-text-color: var(--rui-page-color);
+  --rui-Alert--info__foreground-color: var(--rui-color-info);
+  --rui-Alert--info__background-color: var(--rui-color-white);
+  --rui-Alert--info__text-color: var(--rui-page-color);
 
   // Alerts: type: help
-  --rui-alert-help-foreground-color: var(--rui-color-help);
-  --rui-alert-help-background-color: var(--rui-color-white);
-  --rui-alert-help-text-color: var(--rui-page-color);
+  --rui-Alert--help__foreground-color: var(--rui-color-help);
+  --rui-Alert--help__background-color: var(--rui-color-white);
+  --rui-Alert--help__text-color: var(--rui-page-color);
 
   // Alerts: type: note
-  --rui-alert-note-foreground-color: var(--rui-color-note);
-  --rui-alert-note-background-color: var(--rui-color-white);
-  --rui-alert-note-text-color: var(--rui-page-color);
+  --rui-Alert--note__foreground-color: var(--rui-color-note);
+  --rui-Alert--note__background-color: var(--rui-color-white);
+  --rui-Alert--note__text-color: var(--rui-page-color);
 
   //
   // Buttons
   // =======
 
   // Buttons: common properties
-  --rui-button-font-weight: var(--rui-typography-font-weight-regular);
-  --rui-button-letter-spacing: 0;
-  --rui-button-text-transform: none;
-  --rui-button-border-width: var(--rui-border-width);
-  --rui-button-border-radius: var(--rui-border-radius);
-  --rui-button-disabled-opacity: 0.5;
-  --rui-button-disabled-cursor: not-allowed;
+  --rui-Button__font-weight: var(--rui-typography-font-weight-regular);
+  --rui-Button__letter-spacing: 0;
+  --rui-Button__text-transform: none;
+  --rui-Button__border-width: var(--rui-border-width);
+  --rui-Button__border-radius: var(--rui-border-radius);
+  --rui-Button--disabled__opacity: 0.5;
+  --rui-Button--disabled__cursor: not-allowed;
 
   // Buttons: filled priority
 
   // Buttons: filled priority: primary variant
-  --rui-button-filled-primary-default-color: var(--rui-color-on-primary);
-  --rui-button-filled-primary-default-border-color: var(--rui-color-primary);
-  --rui-button-filled-primary-default-background: var(--rui-color-primary);
-  --rui-button-filled-primary-default-box-shadow: none;
-  --rui-button-filled-primary-hover-color: var(--rui-color-on-primary);
-  --rui-button-filled-primary-hover-border-color: var(--rui-color-primary-dark);
-  --rui-button-filled-primary-hover-background: var(--rui-color-primary-dark);
-  --rui-button-filled-primary-hover-box-shadow: none;
-  --rui-button-filled-primary-active-color: var(--rui-color-on-primary);
-  --rui-button-filled-primary-active-border-color: var(--rui-color-primary-darker);
-  --rui-button-filled-primary-active-background: var(--rui-color-primary-darker);
-  --rui-button-filled-primary-active-box-shadow: none;
+  --rui-Button--filled--primary--default__color: var(--rui-color-on-primary);
+  --rui-Button--filled--primary--default__border-color: var(--rui-color-primary);
+  --rui-Button--filled--primary--default__background: var(--rui-color-primary);
+  --rui-Button--filled--primary--default__box-shadow: none;
+  --rui-Button--filled--primary--hover__color: var(--rui-color-on-primary);
+  --rui-Button--filled--primary--hover__border-color: var(--rui-color-primary-dark);
+  --rui-Button--filled--primary--hover__background: var(--rui-color-primary-dark);
+  --rui-Button--filled--primary--hover__box-shadow: none;
+  --rui-Button--filled--primary--active__color: var(--rui-color-on-primary);
+  --rui-Button--filled--primary--active__border-color: var(--rui-color-primary-darker);
+  --rui-Button--filled--primary--active__background: var(--rui-color-primary-darker);
+  --rui-Button--filled--primary--active__box-shadow: none;
 
   // Buttons: filled priority: secondary variant
-  --rui-button-filled-secondary-default-color: var(--rui-color-on-secondary);
-  --rui-button-filled-secondary-default-border-color: var(--rui-color-secondary);
-  --rui-button-filled-secondary-default-background: var(--rui-color-secondary);
-  --rui-button-filled-secondary-default-box-shadow: none;
-  --rui-button-filled-secondary-hover-color: var(--rui-color-on-secondary);
-  --rui-button-filled-secondary-hover-border-color: var(--rui-color-secondary-dark);
-  --rui-button-filled-secondary-hover-background: var(--rui-color-secondary-dark);
-  --rui-button-filled-secondary-hover-box-shadow: none;
-  --rui-button-filled-secondary-active-color: var(--rui-color-on-secondary);
-  --rui-button-filled-secondary-active-border-color: var(--rui-color-secondary-darker);
-  --rui-button-filled-secondary-active-background: var(--rui-color-secondary-darker);
-  --rui-button-filled-secondary-active-box-shadow: none;
+  --rui-Button--filled--secondary--default__color: var(--rui-color-on-secondary);
+  --rui-Button--filled--secondary--default__border-color: var(--rui-color-secondary);
+  --rui-Button--filled--secondary--default__background: var(--rui-color-secondary);
+  --rui-Button--filled--secondary--default__box-shadow: none;
+  --rui-Button--filled--secondary--hover__color: var(--rui-color-on-secondary);
+  --rui-Button--filled--secondary--hover__border-color: var(--rui-color-secondary-dark);
+  --rui-Button--filled--secondary--hover__background: var(--rui-color-secondary-dark);
+  --rui-Button--filled--secondary--hover__box-shadow: none;
+  --rui-Button--filled--secondary--active__color: var(--rui-color-on-secondary);
+  --rui-Button--filled--secondary--active__border-color: var(--rui-color-secondary-darker);
+  --rui-Button--filled--secondary--active__background: var(--rui-color-secondary-darker);
+  --rui-Button--filled--secondary--active__box-shadow: none;
 
   // Buttons: filled priority: success variant
-  --rui-button-filled-success-default-color: var(--rui-color-on-success);
-  --rui-button-filled-success-default-border-color: var(--rui-color-success);
-  --rui-button-filled-success-default-background: var(--rui-color-success);
-  --rui-button-filled-success-default-box-shadow: none;
-  --rui-button-filled-success-hover-color: var(--rui-color-on-success);
-  --rui-button-filled-success-hover-border-color: var(--rui-color-success-dark);
-  --rui-button-filled-success-hover-background: var(--rui-color-success-dark);
-  --rui-button-filled-success-hover-box-shadow: none;
-  --rui-button-filled-success-active-color: var(--rui-color-on-success);
-  --rui-button-filled-success-active-border-color: var(--rui-color-success-darker);
-  --rui-button-filled-success-active-background: var(--rui-color-success-darker);
-  --rui-button-filled-success-active-box-shadow: none;
+  --rui-Button--filled--success--default__color: var(--rui-color-on-success);
+  --rui-Button--filled--success--default__border-color: var(--rui-color-success);
+  --rui-Button--filled--success--default__background: var(--rui-color-success);
+  --rui-Button--filled--success--default__box-shadow: none;
+  --rui-Button--filled--success--hover__color: var(--rui-color-on-success);
+  --rui-Button--filled--success--hover__border-color: var(--rui-color-success-dark);
+  --rui-Button--filled--success--hover__background: var(--rui-color-success-dark);
+  --rui-Button--filled--success--hover__box-shadow: none;
+  --rui-Button--filled--success--active__color: var(--rui-color-on-success);
+  --rui-Button--filled--success--active__border-color: var(--rui-color-success-darker);
+  --rui-Button--filled--success--active__background: var(--rui-color-success-darker);
+  --rui-Button--filled--success--active__box-shadow: none;
 
   // Buttons: filled priority: warning variant
-  --rui-button-filled-warning-default-color: var(--rui-color-on-warning);
-  --rui-button-filled-warning-default-border-color: var(--rui-color-warning);
-  --rui-button-filled-warning-default-background: var(--rui-color-warning);
-  --rui-button-filled-warning-default-box-shadow: none;
-  --rui-button-filled-warning-hover-color: var(--rui-color-on-warning);
-  --rui-button-filled-warning-hover-border-color: var(--rui-color-warning-dark);
-  --rui-button-filled-warning-hover-background: var(--rui-color-warning-dark);
-  --rui-button-filled-warning-hover-box-shadow: none;
-  --rui-button-filled-warning-active-color: var(--rui-color-on-warning);
-  --rui-button-filled-warning-active-border-color: var(--rui-color-warning-darker);
-  --rui-button-filled-warning-active-background: var(--rui-color-warning-darker);
-  --rui-button-filled-warning-active-box-shadow: none;
+  --rui-Button--filled--warning--default__color: var(--rui-color-on-warning);
+  --rui-Button--filled--warning--default__border-color: var(--rui-color-warning);
+  --rui-Button--filled--warning--default__background: var(--rui-color-warning);
+  --rui-Button--filled--warning--default__box-shadow: none;
+  --rui-Button--filled--warning--hover__color: var(--rui-color-on-warning);
+  --rui-Button--filled--warning--hover__border-color: var(--rui-color-warning-dark);
+  --rui-Button--filled--warning--hover__background: var(--rui-color-warning-dark);
+  --rui-Button--filled--warning--hover__box-shadow: none;
+  --rui-Button--filled--warning--active__color: var(--rui-color-on-warning);
+  --rui-Button--filled--warning--active__border-color: var(--rui-color-warning-darker);
+  --rui-Button--filled--warning--active__background: var(--rui-color-warning-darker);
+  --rui-Button--filled--warning--active__box-shadow: none;
 
   // Buttons: filled priority: danger variant (uses error color)
-  --rui-button-filled-danger-default-color: var(--rui-color-on-error);
-  --rui-button-filled-danger-default-border-color: var(--rui-color-error);
-  --rui-button-filled-danger-default-background: var(--rui-color-error);
-  --rui-button-filled-danger-default-box-shadow: none;
-  --rui-button-filled-danger-hover-color: var(--rui-color-on-error);
-  --rui-button-filled-danger-hover-border-color: var(--rui-color-error-dark);
-  --rui-button-filled-danger-hover-background: var(--rui-color-error-dark);
-  --rui-button-filled-danger-hover-box-shadow: none;
-  --rui-button-filled-danger-active-color: var(--rui-color-on-error);
-  --rui-button-filled-danger-active-border-color: var(--rui-color-error-darker);
-  --rui-button-filled-danger-active-background: var(--rui-color-error-darker);
-  --rui-button-filled-danger-active-box-shadow: none;
+  --rui-Button--filled--danger--default__color: var(--rui-color-on-error);
+  --rui-Button--filled--danger--default__border-color: var(--rui-color-error);
+  --rui-Button--filled--danger--default__background: var(--rui-color-error);
+  --rui-Button--filled--danger--default__box-shadow: none;
+  --rui-Button--filled--danger--hover__color: var(--rui-color-on-error);
+  --rui-Button--filled--danger--hover__border-color: var(--rui-color-error-dark);
+  --rui-Button--filled--danger--hover__background: var(--rui-color-error-dark);
+  --rui-Button--filled--danger--hover__box-shadow: none;
+  --rui-Button--filled--danger--active__color: var(--rui-color-on-error);
+  --rui-Button--filled--danger--active__border-color: var(--rui-color-error-darker);
+  --rui-Button--filled--danger--active__background: var(--rui-color-error-darker);
+  --rui-Button--filled--danger--active__box-shadow: none;
 
   // Buttons: filled priority: dark variant
-  --rui-button-filled-dark-default-color: var(--rui-color-white);
-  --rui-button-filled-dark-default-border-color: var(--rui-color-gray-700);
-  --rui-button-filled-dark-default-background: var(--rui-color-gray-700);
-  --rui-button-filled-dark-default-box-shadow: none;
-  --rui-button-filled-dark-hover-color: var(--rui-color-white);
-  --rui-button-filled-dark-hover-border-color: var(--rui-color-gray-800);
-  --rui-button-filled-dark-hover-background: var(--rui-color-gray-800);
-  --rui-button-filled-dark-hover-box-shadow: none;
-  --rui-button-filled-dark-active-color: var(--rui-color-white);
-  --rui-button-filled-dark-active-border-color: var(--rui-color-gray-900);
-  --rui-button-filled-dark-active-background: var(--rui-color-gray-900);
-  --rui-button-filled-dark-active-box-shadow: none;
+  --rui-Button--filled--dark--default__color: var(--rui-color-white);
+  --rui-Button--filled--dark--default__border-color: var(--rui-color-gray-700);
+  --rui-Button--filled--dark--default__background: var(--rui-color-gray-700);
+  --rui-Button--filled--dark--default__box-shadow: none;
+  --rui-Button--filled--dark--hover__color: var(--rui-color-white);
+  --rui-Button--filled--dark--hover__border-color: var(--rui-color-gray-800);
+  --rui-Button--filled--dark--hover__background: var(--rui-color-gray-800);
+  --rui-Button--filled--dark--hover__box-shadow: none;
+  --rui-Button--filled--dark--active__color: var(--rui-color-white);
+  --rui-Button--filled--dark--active__border-color: var(--rui-color-gray-900);
+  --rui-Button--filled--dark--active__background: var(--rui-color-gray-900);
+  --rui-Button--filled--dark--active__box-shadow: none;
 
   // Buttons: outline priority
 
   // Buttons: outline priority: primary variant
-  --rui-button-outline-primary-default-color: var(--rui-color-primary);
-  --rui-button-outline-primary-default-border-color: var(--rui-color-primary);
-  --rui-button-outline-primary-default-background: transparent;
-  --rui-button-outline-primary-hover-color: var(--rui-color-on-primary);
-  --rui-button-outline-primary-hover-border-color: var(--rui-color-primary-dark);
-  --rui-button-outline-primary-hover-background: var(--rui-color-primary-dark);
-  --rui-button-outline-primary-active-color: var(--rui-color-on-primary);
-  --rui-button-outline-primary-active-border-color: var(--rui-color-primary-darker);
-  --rui-button-outline-primary-active-background: var(--rui-color-primary-darker);
+  --rui-Button--outline--primary--default__color: var(--rui-color-primary);
+  --rui-Button--outline--primary--default__border-color: var(--rui-color-primary);
+  --rui-Button--outline--primary--default__background: transparent;
+  --rui-Button--outline--primary--hover__color: var(--rui-color-on-primary);
+  --rui-Button--outline--primary--hover__border-color: var(--rui-color-primary-dark);
+  --rui-Button--outline--primary--hover__background: var(--rui-color-primary-dark);
+  --rui-Button--outline--primary--active__color: var(--rui-color-on-primary);
+  --rui-Button--outline--primary--active__border-color: var(--rui-color-primary-darker);
+  --rui-Button--outline--primary--active__background: var(--rui-color-primary-darker);
 
   // Buttons: outline priority: secondary variant
-  --rui-button-outline-secondary-default-color: var(--rui-color-secondary);
-  --rui-button-outline-secondary-default-border-color: var(--rui-color-secondary);
-  --rui-button-outline-secondary-default-background: transparent;
-  --rui-button-outline-secondary-hover-color: var(--rui-color-on-secondary);
-  --rui-button-outline-secondary-hover-border-color: var(--rui-color-secondary-dark);
-  --rui-button-outline-secondary-hover-background: var(--rui-color-secondary-dark);
-  --rui-button-outline-secondary-active-color: var(--rui-color-on-secondary);
-  --rui-button-outline-secondary-active-border-color: var(--rui-color-secondary-darker);
-  --rui-button-outline-secondary-active-background: var(--rui-color-secondary-darker);
+  --rui-Button--outline--secondary--default__color: var(--rui-color-secondary);
+  --rui-Button--outline--secondary--default__border-color: var(--rui-color-secondary);
+  --rui-Button--outline--secondary--default__background: transparent;
+  --rui-Button--outline--secondary--hover__color: var(--rui-color-on-secondary);
+  --rui-Button--outline--secondary--hover__border-color: var(--rui-color-secondary-dark);
+  --rui-Button--outline--secondary--hover__background: var(--rui-color-secondary-dark);
+  --rui-Button--outline--secondary--active__color: var(--rui-color-on-secondary);
+  --rui-Button--outline--secondary--active__border-color: var(--rui-color-secondary-darker);
+  --rui-Button--outline--secondary--active__background: var(--rui-color-secondary-darker);
 
   // Buttons: outline priority: success variant
-  --rui-button-outline-success-default-color: var(--rui-color-success);
-  --rui-button-outline-success-default-border-color: var(--rui-color-success);
-  --rui-button-outline-success-default-background: transparent;
-  --rui-button-outline-success-hover-color: var(--rui-color-on-success);
-  --rui-button-outline-success-hover-border-color: var(--rui-color-success-dark);
-  --rui-button-outline-success-hover-background: var(--rui-color-success-dark);
-  --rui-button-outline-success-active-color: var(--rui-color-on-success);
-  --rui-button-outline-success-active-border-color: var(--rui-color-success-darker);
-  --rui-button-outline-success-active-background: var(--rui-color-success-darker);
+  --rui-Button--outline--success--default__color: var(--rui-color-success);
+  --rui-Button--outline--success--default__border-color: var(--rui-color-success);
+  --rui-Button--outline--success--default__background: transparent;
+  --rui-Button--outline--success--hover__color: var(--rui-color-on-success);
+  --rui-Button--outline--success--hover__border-color: var(--rui-color-success-dark);
+  --rui-Button--outline--success--hover__background: var(--rui-color-success-dark);
+  --rui-Button--outline--success--active__color: var(--rui-color-on-success);
+  --rui-Button--outline--success--active__border-color: var(--rui-color-success-darker);
+  --rui-Button--outline--success--active__background: var(--rui-color-success-darker);
 
   // Buttons: outline priority: warning variant
-  --rui-button-outline-warning-default-color: var(--rui-color-warning);
-  --rui-button-outline-warning-default-border-color: var(--rui-color-warning);
-  --rui-button-outline-warning-default-background: transparent;
-  --rui-button-outline-warning-hover-color: var(--rui-color-on-warning);
-  --rui-button-outline-warning-hover-border-color: var(--rui-color-warning-dark);
-  --rui-button-outline-warning-hover-background: var(--rui-color-warning-dark);
-  --rui-button-outline-warning-active-color: var(--rui-color-on-warning);
-  --rui-button-outline-warning-active-border-color: var(--rui-color-warning-darker);
-  --rui-button-outline-warning-active-background: var(--rui-color-warning-darker);
+  --rui-Button--outline--warning--default__color: var(--rui-color-warning);
+  --rui-Button--outline--warning--default__border-color: var(--rui-color-warning);
+  --rui-Button--outline--warning--default__background: transparent;
+  --rui-Button--outline--warning--hover__color: var(--rui-color-on-warning);
+  --rui-Button--outline--warning--hover__border-color: var(--rui-color-warning-dark);
+  --rui-Button--outline--warning--hover__background: var(--rui-color-warning-dark);
+  --rui-Button--outline--warning--active__color: var(--rui-color-on-warning);
+  --rui-Button--outline--warning--active__border-color: var(--rui-color-warning-darker);
+  --rui-Button--outline--warning--active__background: var(--rui-color-warning-darker);
 
   // Buttons: outline priority: danger variant (uses error color)
-  --rui-button-outline-danger-default-color: var(--rui-color-error);
-  --rui-button-outline-danger-default-border-color: var(--rui-color-error);
-  --rui-button-outline-danger-default-background: transparent;
-  --rui-button-outline-danger-hover-color: var(--rui-color-on-error);
-  --rui-button-outline-danger-hover-border-color: var(--rui-color-error-dark);
-  --rui-button-outline-danger-hover-background: var(--rui-color-error-dark);
-  --rui-button-outline-danger-active-color: var(--rui-color-on-error);
-  --rui-button-outline-danger-active-border-color: var(--rui-color-error-darker);
-  --rui-button-outline-danger-active-background: var(--rui-color-error-darker);
+  --rui-Button--outline--danger--default__color: var(--rui-color-error);
+  --rui-Button--outline--danger--default__border-color: var(--rui-color-error);
+  --rui-Button--outline--danger--default__background: transparent;
+  --rui-Button--outline--danger--hover__color: var(--rui-color-on-error);
+  --rui-Button--outline--danger--hover__border-color: var(--rui-color-error-dark);
+  --rui-Button--outline--danger--hover__background: var(--rui-color-error-dark);
+  --rui-Button--outline--danger--active__color: var(--rui-color-on-error);
+  --rui-Button--outline--danger--active__border-color: var(--rui-color-error-darker);
+  --rui-Button--outline--danger--active__background: var(--rui-color-error-darker);
 
   // Buttons: outline priority: dark variant
-  --rui-button-outline-dark-default-color: var(--rui-color-gray-700);
-  --rui-button-outline-dark-default-border-color: var(--rui-color-gray-700);
-  --rui-button-outline-dark-default-background: transparent;
-  --rui-button-outline-dark-hover-color: var(--rui-color-white);
-  --rui-button-outline-dark-hover-border-color: var(--rui-color-gray-800);
-  --rui-button-outline-dark-hover-background: var(--rui-color-gray-800);
-  --rui-button-outline-dark-active-color: var(--rui-color-white);
-  --rui-button-outline-dark-active-border-color: var(--rui-color-gray-900);
-  --rui-button-outline-dark-active-background: var(--rui-color-gray-900);
+  --rui-Button--outline--dark--default__color: var(--rui-color-gray-700);
+  --rui-Button--outline--dark--default__border-color: var(--rui-color-gray-700);
+  --rui-Button--outline--dark--default__background: transparent;
+  --rui-Button--outline--dark--hover__color: var(--rui-color-white);
+  --rui-Button--outline--dark--hover__border-color: var(--rui-color-gray-800);
+  --rui-Button--outline--dark--hover__background: var(--rui-color-gray-800);
+  --rui-Button--outline--dark--active__color: var(--rui-color-white);
+  --rui-Button--outline--dark--active__border-color: var(--rui-color-gray-900);
+  --rui-Button--outline--dark--active__background: var(--rui-color-gray-900);
 
   // Buttons: flat
 
   // Buttons: flat priority: primary variant
-  --rui-button-flat-primary-default-color: var(--rui-color-primary);
-  --rui-button-flat-primary-default-background: transparent;
-  --rui-button-flat-primary-hover-color: var(--rui-color-primary-dark);
-  --rui-button-flat-primary-hover-background: var(--rui-color-primary-light);
-  --rui-button-flat-primary-active-color: var(--rui-color-primary-darker);
-  --rui-button-flat-primary-active-background: var(--rui-color-primary-light);
+  --rui-Button--flat--primary--default__color: var(--rui-color-primary);
+  --rui-Button--flat--primary--default__background: transparent;
+  --rui-Button--flat--primary--hover__color: var(--rui-color-primary-dark);
+  --rui-Button--flat--primary--hover__background: var(--rui-color-primary-light);
+  --rui-Button--flat--primary--active__color: var(--rui-color-primary-darker);
+  --rui-Button--flat--primary--active__background: var(--rui-color-primary-light);
 
   // Buttons: flat priority: secondary variant
-  --rui-button-flat-secondary-default-color: var(--rui-color-secondary);
-  --rui-button-flat-secondary-default-background: transparent;
-  --rui-button-flat-secondary-hover-color: var(--rui-color-secondary-dark);
-  --rui-button-flat-secondary-hover-background: var(--rui-color-secondary-light);
-  --rui-button-flat-secondary-active-color: var(--rui-color-secondary-darker);
-  --rui-button-flat-secondary-active-background: var(--rui-color-secondary-light);
+  --rui-Button--flat--secondary--default__color: var(--rui-color-secondary);
+  --rui-Button--flat--secondary--default__background: transparent;
+  --rui-Button--flat--secondary--hover__color: var(--rui-color-secondary-dark);
+  --rui-Button--flat--secondary--hover__background: var(--rui-color-secondary-light);
+  --rui-Button--flat--secondary--active__color: var(--rui-color-secondary-darker);
+  --rui-Button--flat--secondary--active__background: var(--rui-color-secondary-light);
 
   // Buttons: flat priority: success variant
-  --rui-button-flat-success-default-color: var(--rui-color-success);
-  --rui-button-flat-success-default-background: transparent;
-  --rui-button-flat-success-hover-color: var(--rui-color-success-dark);
-  --rui-button-flat-success-hover-background: var(--rui-color-success-light);
-  --rui-button-flat-success-active-color: var(--rui-color-success-darker);
-  --rui-button-flat-success-active-background: var(--rui-color-success-light);
+  --rui-Button--flat--success--default__color: var(--rui-color-success);
+  --rui-Button--flat--success--default__background: transparent;
+  --rui-Button--flat--success--hover__color: var(--rui-color-success-dark);
+  --rui-Button--flat--success--hover__background: var(--rui-color-success-light);
+  --rui-Button--flat--success--active__color: var(--rui-color-success-darker);
+  --rui-Button--flat--success--active__background: var(--rui-color-success-light);
 
   // Buttons: flat priority: warning variant
-  --rui-button-flat-warning-default-color: var(--rui-color-warning);
-  --rui-button-flat-warning-default-background: transparent;
-  --rui-button-flat-warning-hover-color: var(--rui-color-warning-darker);
-  --rui-button-flat-warning-hover-background: var(--rui-color-warning-light);
-  --rui-button-flat-warning-active-color: var(--rui-color-warning-darker);
-  --rui-button-flat-warning-active-background: var(--rui-color-warning-light);
+  --rui-Button--flat--warning--default__color: var(--rui-color-warning);
+  --rui-Button--flat--warning--default__background: transparent;
+  --rui-Button--flat--warning--hover__color: var(--rui-color-warning-darker);
+  --rui-Button--flat--warning--hover__background: var(--rui-color-warning-light);
+  --rui-Button--flat--warning--active__color: var(--rui-color-warning-darker);
+  --rui-Button--flat--warning--active__background: var(--rui-color-warning-light);
 
   // Buttons: flat priority: danger variant (uses error color)
-  --rui-button-flat-danger-default-color: var(--rui-color-error);
-  --rui-button-flat-danger-default-background: transparent;
-  --rui-button-flat-danger-hover-color: var(--rui-color-error-dark);
-  --rui-button-flat-danger-hover-background: var(--rui-color-error-light);
-  --rui-button-flat-danger-active-color: var(--rui-color-error-darker);
-  --rui-button-flat-danger-active-background: var(--rui-color-error-light);
+  --rui-Button--flat--danger--default__color: var(--rui-color-error);
+  --rui-Button--flat--danger--default__background: transparent;
+  --rui-Button--flat--danger--hover__color: var(--rui-color-error-dark);
+  --rui-Button--flat--danger--hover__background: var(--rui-color-error-light);
+  --rui-Button--flat--danger--active__color: var(--rui-color-error-darker);
+  --rui-Button--flat--danger--active__background: var(--rui-color-error-light);
 
   // Buttons: flat priority: dark variant
-  --rui-button-flat-dark-default-color: var(--rui-color-gray-700);
-  --rui-button-flat-dark-default-background: transparent;
-  --rui-button-flat-dark-hover-color: var(--rui-color-gray-800);
-  --rui-button-flat-dark-hover-background: var(--rui-color-gray-50);
-  --rui-button-flat-dark-active-color: var(--rui-color-gray-900);
-  --rui-button-flat-dark-active-background: var(--rui-color-gray-50);
+  --rui-Button--flat--dark--default__color: var(--rui-color-gray-700);
+  --rui-Button--flat--dark--default__background: transparent;
+  --rui-Button--flat--dark--hover__color: var(--rui-color-gray-800);
+  --rui-Button--flat--dark--hover__background: var(--rui-color-gray-50);
+  --rui-Button--flat--dark--active__color: var(--rui-color-gray-900);
+  --rui-Button--flat--dark--active__background: var(--rui-color-gray-50);
 
   // Buttons: sizes
 
   // Buttons: sizes: small
-  --rui-button-small-height: 1.75rem;
-  --rui-button-small-padding-x: var(--rui-spacing-3);
-  --rui-button-small-font-size: var(--rui-typography-size-small);
+  --rui-Button--small__height: 1.75rem;
+  --rui-Button--small__padding-x: var(--rui-spacing-3);
+  --rui-Button--small__font-size: var(--rui-typography-size-small);
 
   // Buttons: sizes: medium
-  --rui-button-medium-height: 2.25rem;
-  --rui-button-medium-padding-x: var(--rui-spacing-4);
-  --rui-button-medium-font-size: var(--rui-typography-size-0);
+  --rui-Button--medium__height: 2.25rem;
+  --rui-Button--medium__padding-x: var(--rui-spacing-4);
+  --rui-Button--medium__font-size: var(--rui-typography-size-0);
 
   // Buttons: sizes: large
-  --rui-button-large-height: 2.75rem;
-  --rui-button-large-padding-x: var(--rui-spacing-5);
-  --rui-button-large-font-size: var(--rui-typography-size-1);
+  --rui-Button--large__height: 2.75rem;
+  --rui-Button--large__padding-x: var(--rui-spacing-5);
+  --rui-Button--large__font-size: var(--rui-typography-size-1);
 
   //
   // ButtonGroup
   // ===========
 
   // ButtonGroup: filled buttons
-  --rui-button-group-filled-gap: calc(-1 * var(--rui-button-border-width));
-  --rui-button-group-filled-separator-width: var(--rui-button-border-width);
-  --rui-button-group-filled-separator-color: currentColor;
+  --rui-ButtonGroup--filled__gap: calc(-1 * var(--rui-Button__border-width));
+  --rui-ButtonGroup--filled__separator__width: var(--rui-Button__border-width);
+  --rui-ButtonGroup--filled__separator__color: currentColor;
 
   // ButtonGroup: flat buttons
-  --rui-button-group-flat-gap: var(--rui-button-border-width);
-  --rui-button-group-flat-separator-width: var(--rui-button-group-flat-gap);
-  --rui-button-group-flat-separator-color: currentColor;
+  --rui-ButtonGroup--flat__gap: var(--rui-Button__border-width);
+  --rui-ButtonGroup--flat__separator__width: var(--rui-ButtonGroup--flat__gap);
+  --rui-ButtonGroup--flat__separator__color: currentColor;
 
   // ButtonGroup: outline buttons
-  --rui-button-group-outline-gap: calc(-1 * var(--rui-button-border-width));
+  --rui-ButtonGroup--outline__gap: calc(-1 * var(--rui-Button__border-width));
 
   //
   // Cards
   // =====
 
   // Cards: common properties
-  --rui-card-padding: var(--rui-spacing-4);
-  --rui-card-dense-padding: var(--rui-spacing-2);
-  --rui-card-border-width: var(--rui-border-width);
-  --rui-card-border-radius: var(--rui-border-radius);
-  --rui-card-background-color: var(--rui-color-white);
+  --rui-Card__padding: var(--rui-spacing-4);
+  --rui-Card__border-width: var(--rui-border-width);
+  --rui-Card__border-radius: var(--rui-border-radius);
+  --rui-Card__background-color: var(--rui-color-white);
+  --rui-Card--dense__padding: var(--rui-spacing-2);
 
   // Cards: variants
-  --rui-card-flat-border-color: transparent;
-  --rui-card-bordered-border-color: var(--rui-color-gray-200);
+  --rui-Card--flat__border-color: transparent;
+  --rui-Card--bordered__border-color: var(--rui-color-gray-200);
 
   // Cards: types
-  --rui-card-success-border-color: var(--rui-color-success);
-  --rui-card-warning-border-color: var(--rui-color-warning);
-  --rui-card-error-border-color: var(--rui-color-error);
-  --rui-card-help-border-color: var(--rui-color-help);
-  --rui-card-info-border-color: var(--rui-color-info);
-  --rui-card-note-border-color: var(--rui-color-note);
+  --rui-Card--success__border-color: var(--rui-color-success);
+  --rui-Card--warning__border-color: var(--rui-color-warning);
+  --rui-Card--error__border-color: var(--rui-color-error);
+  --rui-Card--help__border-color: var(--rui-color-help);
+  --rui-Card--info__border-color: var(--rui-color-info);
+  --rui-Card--note__border-color: var(--rui-color-note);
 
   // Cards: raised
-  --rui-card-raised-box-shadow: 0 0.01rem 0.65rem -0.1rem #{rgba(0, 0, 0, 0.3)};
+  --rui-Card--raised__box-shadow: 0 0.01rem 0.65rem -0.1rem #{rgba(0, 0, 0, 0.3)};
 
   // Cards: disabled
-  --rui-card-disabled-background-color: var(--rui-color-gray-50);
-  --rui-card-disabled-opacity: 0.6;
+  --rui-Card--disabled__background-color: var(--rui-color-gray-50);
+  --rui-Card--disabled__opacity: 0.6;
 
   //
   // Form Fields
@@ -499,170 +547,140 @@
   //    inline grid.
 
   // Forms fields: common properties
-  --rui-form-field-label-color: inherit;
-  --rui-form-field-label-font-size: var(--rui-typography-size-0);
-  --rui-form-field-help-text-font-size: var(--rui-typography-size-small);
-  --rui-form-field-help-text-font-style: normal;
-  --rui-form-field-help-text-color: var(--rui-color-gray-500);
-  --rui-form-field-required-sign: '\00a0*'; // 2.
-  --rui-form-field-required-sign-color: var(--rui-color-gray-500);
+  --rui-FormField__label__color: inherit;
+  --rui-FormField__label__font-size: var(--rui-typography-size-0);
+  --rui-FormField__help-text__font-size: var(--rui-typography-size-small);
+  --rui-FormField__help-text__font-style: normal;
+  --rui-FormField__help-text__color: var(--rui-color-gray-500);
+  --rui-FormField--required__sign: '\00a0*'; // 2.
+  --rui-FormField--required__sign__color: var(--rui-color-gray-500);
 
   // Form fields: horizontal layout
-  --rui-form-field-horizontal-label-text-align: left;
-  --rui-form-field-horizontal-label-min-width: 0;
-  --rui-form-field-horizontal-label-width: minmax(auto, 50%); // 3.
-  --rui-form-field-horizontal-label-vertical-alignment: initial;
-  --rui-form-field-horizontal-field-vertical-alignment: initial;
-  --rui-form-field-horizontal-full-width-label-width: fit-content(50%);
+  --rui-FormField--horizontal__label__text-align: left;
+  --rui-FormField--horizontal__label__min-width: 0;
+  --rui-FormField--horizontal__label__width: minmax(auto, 50%); // 3.
+  --rui-FormField--horizontal__label__vertical-alignment: initial;
+  --rui-FormField--horizontal__field__vertical-alignment: initial;
+  --rui-FormField--horizontal--full-width__label__width: fit-content(50%);
 
   // Forms fields: disabled state
-  --rui-form-field-disabled-cursor: not-allowed;
-  --rui-form-field-disabled-opacity: 0.5;
+  --rui-FormField--disabled__cursor: not-allowed;
+  --rui-FormField--disabled__opacity: 0.5;
 
   // Form fields: validation states: invalid
-  --rui-form-field-invalid-default-border-color: var(--rui-color-error);
-  --rui-form-field-invalid-default-background: var(--rui-color-error-light);
-  --rui-form-field-invalid-default-check-background-color: var(--rui-form-field-invalid-default-background);
-  --rui-form-field-invalid-default-surrounding-text-color: var(--rui-color-error);
-  --rui-form-field-invalid-checked-check-background-color: var(--rui-form-field-invalid-default-border-color);
+  --rui-FormField--invalid--default__border-color: var(--rui-color-error);
+  --rui-FormField--invalid--default__background: var(--rui-color-error-light);
+  --rui-FormField--invalid--default__check-background-color: var(--rui-FormField--invalid--default__background);
+  --rui-FormField--invalid--default__surrounding-text-color: var(--rui-color-error);
+  --rui-FormField--invalid--checked__check-background-color: var(--rui-FormField--invalid--default__border-color);
 
   // Form fields: validation states: valid
-  --rui-form-field-valid-default-border-color: var(--rui-color-success);
-  --rui-form-field-valid-default-background: var(--rui-color-success-light);
-  --rui-form-field-valid-default-check-background-color: var(--rui-form-field-valid-default-background);
-  --rui-form-field-valid-default-surrounding-text-color: var(--rui-color-success);
-  --rui-form-field-valid-checked-check-background-color: var(--rui-form-field-valid-default-border-color);
+  --rui-FormField--valid--default__border-color: var(--rui-color-success);
+  --rui-FormField--valid--default__background: var(--rui-color-success-light);
+  --rui-FormField--valid--default__check-background-color: var(--rui-FormField--valid--default__background);
+  --rui-FormField--valid--default__surrounding-text-color: var(--rui-color-success);
+  --rui-FormField--valid--checked__check-background-color: var(--rui-FormField--valid--default__border-color);
 
   // Form fields: validation states: warning
-  --rui-form-field-warning-default-border-color: var(--rui-color-warning-dark);
-  --rui-form-field-warning-default-background: var(--rui-color-warning-light);
-  --rui-form-field-warning-default-check-background-color: var(--rui-form-field-warning-default-background);
-  --rui-form-field-warning-default-surrounding-text-color: var(--rui-color-warning-darker);
-  --rui-form-field-warning-checked-check-background-color: var(--rui-form-field-warning-default-border-color);
+  --rui-FormField--warning--default__border-color: var(--rui-color-warning-dark);
+  --rui-FormField--warning--default__background: var(--rui-color-warning-light);
+  --rui-FormField--warning--default__check-background-color: var(--rui-FormField--warning--default__background);
+  --rui-FormField--warning--default__surrounding-text-color: var(--rui-color-warning-darker);
+  --rui-FormField--warning--checked__check-background-color: var(--rui-FormField--warning--default__border-color);
 
   // Form fields: box fields
-  --rui-form-field-box-input-width: auto; // 1.
-  --rui-form-field-box-input-min-width: 240px; // 1.
-  --rui-form-field-box-border-width: var(--rui-border-width);
-  --rui-form-field-box-border-radius: var(--rui-border-radius);
-  --rui-form-field-box-placeholder-color: var(--rui-color-gray-500);
-  --rui-form-field-box-select-caret-border-style: none;
-  --rui-form-field-box-select-caret-background: transparent;
-  --rui-form-field-box-select-option-disabled-color: var(--rui-color-gray-300);
+  --rui-FormField--box__border-width: var(--rui-border-width);
+  --rui-FormField--box__border-radius: var(--rui-border-radius);
+  --rui-FormField--box__input__width: auto; // 1.
+  --rui-FormField--box__input__min-width: 240px; // 1.
+  --rui-FormField--box__placeholder__color: var(--rui-color-gray-500);
+  --rui-FormField--box--select__caret__border-style: none;
+  --rui-FormField--box--select__caret__background: transparent;
+  --rui-FormField--box--select__option--disabled__color: var(--rui-color-gray-300);
 
   // Form fields: box field sizes: small
-  --rui-form-field-box-small-height: 1.75rem;
-  --rui-form-field-box-small-padding-y: 0.0625rem;
-  --rui-form-field-box-small-padding-x: var(--rui-spacing-2);
-  --rui-form-field-box-small-font-size: var(--rui-typography-size-small);
+  --rui-FormField--box--small__height: 1.75rem;
+  --rui-FormField--box--small__padding-y: 0.0625rem;
+  --rui-FormField--box--small__padding-x: var(--rui-spacing-2);
+  --rui-FormField--box--small__font-size: var(--rui-typography-size-small);
 
   // Form fields: box field sizes: medium
-  --rui-form-field-box-medium-height: 2.25rem;
-  --rui-form-field-box-medium-padding-y: 0.3125rem;
-  --rui-form-field-box-medium-padding-x: var(--rui-spacing-3);
-  --rui-form-field-box-medium-font-size: var(--rui-typography-size-0);
+  --rui-FormField--box--medium__height: 2.25rem;
+  --rui-FormField--box--medium__padding-y: 0.3125rem;
+  --rui-FormField--box--medium__padding-x: var(--rui-spacing-3);
+  --rui-FormField--box--medium__font-size: var(--rui-typography-size-0);
 
   // Form fields: box field sizes: large
-  --rui-form-field-box-large-height: 2.75rem;
-  --rui-form-field-box-large-padding-y: 0.5625rem;
-  --rui-form-field-box-large-padding-x: var(--rui-spacing-4);
-  --rui-form-field-box-large-font-size: var(--rui-typography-size-1);
+  --rui-FormField--box--large__height: 2.75rem;
+  --rui-FormField--box--large__padding-y: 0.5625rem;
+  --rui-FormField--box--large__padding-x: var(--rui-spacing-4);
+  --rui-FormField--box--large__font-size: var(--rui-typography-size-1);
 
   // Form fields: box field variants: filled variant interaction states
-  --rui-form-field-box-filled-default-color: var(--rui-page-color);
-  --rui-form-field-box-filled-default-border-color: var(--rui-color-gray-200);
-  --rui-form-field-box-filled-default-background: var(--rui-color-gray-50);
-  --rui-form-field-box-filled-default-box-shadow: none;
-  --rui-form-field-box-filled-hover-border-color: var(--rui-color-gray-500);
-  --rui-form-field-box-filled-focus-border-color: var(--rui-color-primary);
+  --rui-FormField--box--filled--default__color: var(--rui-page-color);
+  --rui-FormField--box--filled--default__border-color: var(--rui-color-gray-200);
+  --rui-FormField--box--filled--default__background: var(--rui-color-gray-50);
+  --rui-FormField--box--filled--default__box-shadow: none;
+  --rui-FormField--box--filled--hover__border-color: var(--rui-color-gray-500);
+  --rui-FormField--box--filled--focus__border-color: var(--rui-color-primary);
 
   // Form fields: box field variants: outline variant interaction states
-  --rui-form-field-box-outline-default-color: var(--rui-page-color);
-  --rui-form-field-box-outline-default-border-color: var(--rui-color-gray-200);
-  --rui-form-field-box-outline-default-background: var(--rui-color-white);
-  --rui-form-field-box-outline-default-box-shadow: none;
-  --rui-form-field-box-outline-hover-border-color: var(--rui-color-gray-500);
-  --rui-form-field-box-outline-focus-border-color: var(--rui-color-primary);
+  --rui-FormField--box--outline--default__color: var(--rui-page-color);
+  --rui-FormField--box--outline--default__border-color: var(--rui-color-gray-200);
+  --rui-FormField--box--outline--default__background: var(--rui-color-white);
+  --rui-FormField--box--outline--default__box-shadow: none;
+  --rui-FormField--box--outline--hover__border-color: var(--rui-color-gray-500);
+  --rui-FormField--box--outline--focus__border-color: var(--rui-color-primary);
 
   // Form fields: check fields
-  --rui-form-field-check-input-size: 1.125rem;
-  --rui-form-field-check-input-border-width: var(--rui-form-field-box-border-width);
-  --rui-form-field-check-input-focus-box-shadow: var(--rui-focus-box-shadow);
-  --rui-form-field-check-tap-target-size: var(--rui-tap-target-size);
+  --rui-FormField--check__input__size: 1.125rem;
+  --rui-FormField--check__input__border-width: var(--rui-FormField--box__border-width);
+  --rui-FormField--check__input--focus__box-shadow: var(--rui-focus-box-shadow);
+  --rui-FormField--check__tap-target-size: var(--rui-tap-target-size);
 
   // Form fields: check fields, component specific
   // stylelint-disable function-url-quotes
-  --rui-form-field-check-input-checkbox-border-radius: var(--rui-form-field-box-border-radius);
-  --rui-form-field-check-input-checkbox-checked-background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>"))};
-  --rui-form-field-check-input-radio-border-radius: 50%;
-  --rui-form-field-check-input-radio-checked-background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#ffffff'/></svg>"))};
-  --rui-form-field-check-input-toggle-width: 2.25rem;
-  --rui-form-field-check-input-toggle-border-radius: 0.5625rem;
-  --rui-form-field-check-input-toggle-background-size: contain;
-  --rui-form-field-check-input-toggle-default-background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#cccccc'/></svg>"))};
-  --rui-form-field-check-input-toggle-default-background-position: left center;
-  --rui-form-field-check-input-toggle-checked-background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#ffffff'/></svg>"))};
-  --rui-form-field-check-input-toggle-checked-background-position: right center;
+  --rui-FormField--check__input--checkbox__border-radius: var(--rui-FormField--box__border-radius);
+  --rui-FormField--check__input--checkbox--checked__background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>"))};
+  --rui-FormField--check__input--radio__border-radius: 50%;
+  --rui-FormField--check__input--radio--checked__background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='2' fill='#ffffff'/></svg>"))};
+  --rui-FormField--check__input--toggle__width: 2.25rem;
+  --rui-FormField--check__input--toggle__border-radius: 0.5625rem;
+  --rui-FormField--check__input--toggle__background-size: contain;
+  --rui-FormField--check__input--toggle--default__background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#cccccc'/></svg>"))};
+  --rui-FormField--check__input--toggle--default__background-position: left center;
+  --rui-FormField--check__input--toggle--checked__background-image: #{svg.escape(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#ffffff'/></svg>"))};
+  --rui-FormField--check__input--toggle--checked__background-position: right center;
   // stylelint-enable function-url-quotes
 
   // Form fields: check fields interaction states
-  --rui-form-field-check-default-border-color: var(--rui-color-gray-200);
-  --rui-form-field-check-default-check-background-color: var(--rui-color-white);
-  --rui-form-field-check-checked-border-color: var(--rui-color-active);
-  --rui-form-field-check-checked-check-background-color: var(--rui-color-active);
-
-  //
-  // FormLayout
-  // ==========
-
-  --rui-form-layout-horizontal-label-auto-width: auto;
-  --rui-form-layout-horizontal-label-limited-width: fit-content(50%);
-  --rui-form-layout-horizontal-label-default-width: 10em;
-  --rui-form-layout-row-gap: var(--rui-spacing-4);
-
-  //
-  // Grid
-  // ====
-
-  --rui-grid-columns: 1fr;
-  --rui-grid-column-gap: var(--rui-spacing-4);
-  --rui-grid-rows: auto;
-  --rui-grid-row-gap: var(--rui-spacing-4);
-  --rui-grid-auto-flow: initial;
-  --rui-grid-align-content: initial;
-  --rui-grid-align-items: initial;
-  --rui-grid-justify-content: initial;
-  --rui-grid-justify-items: initial;
+  --rui-FormField--check--default__border-color: var(--rui-color-gray-200);
+  --rui-FormField--check--default__check-background-color: var(--rui-color-white);
+  --rui-FormField--check--checked__border-color: var(--rui-color-active);
+  --rui-FormField--check--checked__check-background-color: var(--rui-color-active);
 
   //
   // Modal
   // =====
 
-  --rui-modal-background: var(--rui-color-white);
-  --rui-modal-box-shadow: none;
-  --rui-modal-footer-background: var(--rui-color-gray-100);
-  --rui-modal-overlay-background: rgba(0, 0, 0, 0.5);
-  --rui-modal-size-auto-min-width: 18rem;
-  --rui-modal-size-auto-max-width: 60rem;
-  --rui-modal-size-small-width: 20rem;
-  --rui-modal-size-medium-width: 40rem;
-  --rui-modal-size-large-width: 60rem;
-  --rui-modal-size-fullscreen-height: 100%;
-  --rui-modal-size-fullscreen-width: 100%;
-  --rui-modal-outer-offset-xs: var(--rui-spacing-2);
-  --rui-modal-outer-offset-sm: var(--rui-spacing-6);
+  --rui-Modal__background: var(--rui-color-white);
+  --rui-Modal__box-shadow: none;
+  --rui-Modal__outer-spacing--xs: var(--rui-spacing-2);
+  --rui-Modal__outer-spacing--sm: var(--rui-spacing-6);
+  --rui-Modal__footer__background: var(--rui-color-gray-100);
+  --rui-Modal__backdrop__background: rgba(0, 0, 0, 0.5);
+  --rui-Modal--auto__min-width: 18rem;
+  --rui-Modal--auto__max-width: 60rem;
+  --rui-Modal--small__width: 20rem;
+  --rui-Modal--medium__width: 40rem;
+  --rui-Modal--large__width: 60rem;
+  --rui-Modal--fullscreen__width: 100%;
+  --rui-Modal--fullscreen__height: 100%;
 
   //
   // ScrollView
   // ==========
 
-  --rui-scrollview-arrow-initial-offset: -0.5rem;
-  --rui-scrollview-shadow-initial-offset: -1rem;
-
-  //
-  // Toolbar
-  // =======
-
-  --rui-toolbar-spacing: var(--rui-spacing-2);
-  --rui-toolbar-spacing-dense: var(--rui-spacing-1);
+  --rui-ScrollView__arrow__initial-offset: -0.5rem;
+  --rui-ScrollView__shadow__initial-offset: -1rem;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const StyleLintPlugin = require('stylelint-webpack-plugin');
 const VisualizerPlugin = require('webpack-visualizer-plugin');
 
 const MAX_DEVELOPMENT_OUTPUT_SIZE = 2400000;
-const MAX_PRODUCTION_OUTPUT_SIZE = 280000;
+const MAX_PRODUCTION_OUTPUT_SIZE = 285000;
 
 module.exports = (env, argv) => ({
   devtool: argv.mode === 'production'


### PR DESCRIPTION
Custom properties have been split into three groups:

1. design tokens,
2. layout components,
3. UI components.

Syntax of design tokens remains the same, ie. lowercase with hyphenation: `--rui-color-primary`, `--rui-spacing-1`.

Syntax of layout and UI component properties has been changed to BEM-like (or SUIT-CSS-like, more precisely) notation:
`--rui-Alert__padding`, `--rui-FormLayout__row-gap`, `--rui-Modal__backdrop__background`, `--rui-ButtonGroup--filled__gap`,
`--rui-Button--filled--primary--default__color`, `--rui-FormField--check__input--toggle--default__background-position`, etc.

On top of that, some custom property names have been refactored to better fit global naming system (see theming options of `Toolbar`, `Modal`, and more).

Closes #243.