### PR TITLE
Introduce `Paper` component as a primary option to hold larger content areas

### DIFF
--- a/src/lib/components/ui/Card/README.mdx
+++ b/src/lib/components/ui/Card/README.mdx
@@ -46,11 +46,17 @@ See [API](#api) for all available options.
   [customize](/customize/theming/overview) the default appearance to make it stand
   out on white surfaces.
 
-- Use options [CardBody](#cardbody) and [CardFooter](#cardfooter) components to
+- Use optional [CardBody](#cardbody) and [CardFooter](#cardfooter) components to
   provide your content with expected spacing.
 
 - Use **medium or low-emphasis buttons** when there are more cards, eg. in a
   grid. It will help you keep the UI clean and easy to scan.
+
+- **Card, or Paper?** Card is a versatile surface for displaying content.
+  However, there is also the [Paper](/components/ui/paper) component. While Card
+  is designed for displaying items (and also supports more visual options),
+  Paper is usually used to hold larger content areas like lists, grids, or
+  forms.
 
 ## Card Composition
 

--- a/src/lib/components/ui/Paper/Paper.jsx
+++ b/src/lib/components/ui/Paper/Paper.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withProviderContext } from '../../../provider';
+import styles from './Paper.scss';
+
+export const Paper = ({
+  children,
+  id,
+  raised,
+}) => (
+  <div
+    className={[
+      styles.root,
+      raised ? styles.rootRaised : '',
+    ].join(' ')}
+    id={id}
+  >
+    {children}
+  </div>
+);
+
+Paper.defaultProps = {
+  children: null,
+  id: undefined,
+  raised: false,
+};
+
+Paper.propTypes = {
+  /**
+   * Content to be placed onto Paper.
+   */
+  children: PropTypes.node,
+  /**
+   * ID of the root HTML element.
+   */
+  id: PropTypes.string,
+  /**
+   * Add shadow to pull the Paper above surface.
+   */
+  raised: PropTypes.bool,
+};
+
+export const PaperWithContext = withProviderContext(Paper, 'Paper');
+
+export default PaperWithContext;

--- a/src/lib/components/ui/Paper/Paper.scss
+++ b/src/lib/components/ui/Paper/Paper.scss
@@ -1,0 +1,15 @@
+@use 'theme';
+
+.root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: theme.$padding;
+  border: theme.$border-width solid theme.$border-color;
+  border-radius: theme.$border-radius;
+  background-color: theme.$background-color;
+}
+
+.rootRaised {
+  box-shadow: theme.$raised-box-shadow;
+}

--- a/src/lib/components/ui/Paper/README.mdx
+++ b/src/lib/components/ui/Paper/README.mdx
@@ -1,0 +1,69 @@
+---
+name: Paper
+menu: 'UI'
+route: /components/ui/paper
+---
+
+# Paper
+
+import {
+  Playground,
+  Props,
+} from 'docz'
+import { Paper } from './Paper'
+
+Paper is a basic surface to hold content.
+
+## Basic Usage
+
+To implement the Paper component, you need to import it first:
+
+```js
+import { Paper } from '@react-ui-org/react-ui';
+```
+
+And use it:
+
+<Playground>
+  <Paper>
+    Hello!
+  </Paper>
+</Playground>
+
+See [API](#api) for all available options.
+
+## General Guidelines
+
+- Paper is **designed for non-white background.** You may want to either use its
+  [raised variant](#raised-paper) or [customize](/customize/theming/overview)
+  the default appearance to make it stand out on white background.
+
+- **Paper, or Card?** Paper is a basic surface to put content on. However,
+  there is also the [Card](/components/ui/card) component. While Paper is
+  usually used to hold larger content areas like lists, grids, or forms, Card is
+  designed for displaying items. Card also supports more visual options.
+
+## Raised Paper
+
+Add optional shadow to lift the paper above background.
+
+<Playground>
+  <Paper raised>
+    Hello! I&apos;m paper and I&apos;m raised.
+  </Paper>
+</Playground>
+
+## API
+
+<Props table of={Paper} />
+
+## Theming
+
+| Custom Property                                      | Description                                                  |
+|------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Paper__padding`                               | Padding of Paper                                             |
+| `--rui-Paper__border-width`                          | Border width                                                 |
+| `--rui-Paper__border-color`                          | Border color                                                 |
+| `--rui-Paper__border-radius`                         | Corner radius                                                |
+| `--rui-Paper__background-color`                      | Paper background color                                       |
+| `--rui-Paper--raised__box-shadow`                    | Box shadow of raised paper                                   |

--- a/src/lib/components/ui/Paper/__tests__/Paper.test.jsx
+++ b/src/lib/components/ui/Paper/__tests__/Paper.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Paper } from '../Paper';
+
+describe('rendering', () => {
+  it('renders correctly', () => {
+    const tree = shallow(<Paper><p>Paper content</p></Paper>);
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with all props', () => {
+    const tree = shallow(
+      <Paper id="custom-id" raised>
+        <p>Paper content</p>
+      </Paper>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/ui/Paper/__tests__/__snapshots__/Paper.test.jsx.snap
+++ b/src/lib/components/ui/Paper/__tests__/__snapshots__/Paper.test.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering renders correctly 1`] = `
+<div
+  className="root "
+>
+  <p>
+    Paper content
+  </p>
+</div>
+`;
+
+exports[`rendering renders correctly with all props 1`] = `
+<div
+  className="root rootRaised"
+  id="custom-id"
+>
+  <p>
+    Paper content
+  </p>
+</div>
+`;

--- a/src/lib/components/ui/Paper/_theme.scss
+++ b/src/lib/components/ui/Paper/_theme.scss
@@ -1,0 +1,6 @@
+$padding: var(--rui-Paper__padding);
+$border-width: var(--rui-Paper__border-width);
+$border-color: var(--rui-Paper__border-color);
+$border-radius: var(--rui-Paper__border-radius);
+$background-color: var(--rui-Paper__background-color);
+$raised-box-shadow: var(--rui-Paper--raised__box-shadow);

--- a/src/lib/components/ui/Paper/index.js
+++ b/src/lib/components/ui/Paper/index.js
@@ -1,0 +1,1 @@
+export { default } from './Paper';

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -42,6 +42,7 @@ export {
 export { default as CheckboxField } from './components/ui/CheckboxField';
 export { default as FileInputField } from './components/ui/FileInputField';
 export { default as Modal } from './components/ui/Modal';
+export { default as Paper } from './components/ui/Paper';
 export { default as Radio } from './components/ui/Radio';
 export { default as ScrollView } from './components/ui/ScrollView';
 export { default as SelectField } from './components/ui/SelectField';

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -136,6 +136,9 @@
   --rui-border-width: 1px;
   --rui-border-radius: 0.25rem;
 
+  // Elevations
+  --rui-elevation-1: 0 0.01rem 0.65rem -0.1rem #{rgba(0, 0, 0, 0.3)};
+
   // Accessibility
   --rui-tap-target-size: 10mm;
   --rui-focus-box-shadow: 0 0 0 0.2em var(--rui-color-active-focus);
@@ -527,7 +530,7 @@
   --rui-Card--note__border-color: var(--rui-color-note);
 
   // Cards: raised
-  --rui-Card--raised__box-shadow: 0 0.01rem 0.65rem -0.1rem #{rgba(0, 0, 0, 0.3)};
+  --rui-Card--raised__box-shadow: var(--rui-elevation-1);
 
   // Cards: disabled
   --rui-Card--disabled__background-color: var(--rui-color-gray-50);
@@ -676,6 +679,17 @@
   --rui-Modal--large__width: 60rem;
   --rui-Modal--fullscreen__width: 100%;
   --rui-Modal--fullscreen__height: 100%;
+
+  //
+  // Paper
+  // =====
+
+  --rui-Paper__padding: var(--rui-spacing-4);
+  --rui-Paper__border-width: 0;
+  --rui-Paper__border-color: transparent;
+  --rui-Paper__border-radius: var(--rui-border-radius);
+  --rui-Paper__background-color: var(--rui-color-white);
+  --rui-Paper--raised__box-shadow: var(--rui-elevation-1);
 
   //
   // ScrollView


### PR DESCRIPTION
Extract `Paper` from `Card` as dicussed in https://github.com/react-ui-org/react-ui/pull/278#issuecomment-857576378.

<img width="881" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/121736590-0afd3a80-caf8-11eb-96b8-c35f70fd3bfb.png">
