### PR TITLE
Introduce `Text` component to control wrapping of text content (#286)

### DIFF
--- a/src/docs/_components/Placeholder/Placeholder.jsx
+++ b/src/docs/_components/Placeholder/Placeholder.jsx
@@ -8,6 +8,7 @@ export const Placeholder = ({
   dark,
   height,
   inline,
+  width,
 }) => (
   <div
     className={[
@@ -16,7 +17,10 @@ export const Placeholder = ({
       dark ? styles.rootDark : '',
       inline ? styles.rootInline : '',
     ].join(' ')}
-    style={height && { '--rui-local-height': height }}
+    style={{
+      '--rui-local-height': height,
+      '--rui-local-width': width,
+    }}
   >
     {children}
   </div>
@@ -28,6 +32,7 @@ Placeholder.defaultProps = {
   dark: false,
   height: null,
   inline: false,
+  width: null,
 };
 
 Placeholder.propTypes = {
@@ -39,6 +44,7 @@ Placeholder.propTypes = {
   dark: PropTypes.bool,
   height: PropTypes.string,
   inline: PropTypes.bool,
+  width: PropTypes.string,
 };
 
 export default Placeholder;

--- a/src/docs/_components/Placeholder/Placeholder.scss
+++ b/src/docs/_components/Placeholder/Placeholder.scss
@@ -3,9 +3,8 @@
 @use '../../../lib/styles/tools/spacing';
 
 .root {
-  --rui-local-height: auto;
-
-  height: var(--rui-local-height);
+  width: var(--rui-local-width, auto);
+  height: var(--rui-local-height, auto);
   padding: spacing.of(3);
   background-color: colors.$white;
 }

--- a/src/lib/components/layout/Toolbar/README.mdx
+++ b/src/lib/components/layout/Toolbar/README.mdx
@@ -293,6 +293,10 @@ Try resizing the playground below to see how it works.
   </>
 </Playground>
 
+👉 Depending on your situation, you may need to further control wrapping of text
+content placed within Toolbar. The [Text](/components/ui/text) component is
+designed specifically for this kind of job.
+
 ## API
 
 <Props table of={Toolbar} />

--- a/src/lib/components/ui/Text/README.mdx
+++ b/src/lib/components/ui/Text/README.mdx
@@ -1,0 +1,217 @@
+---
+name: Text
+menu: 'UI'
+route: /components/ui/text
+---
+
+# Text
+
+import {
+  Playground,
+  Props,
+} from 'docz'
+import { Placeholder } from '../../../../docs/_components/Placeholder/Placeholder'
+import { Toolbar } from '../../layout/Toolbar/Toolbar'
+import { ToolbarGroup } from '../../layout/Toolbar/ToolbarGroup'
+import { ToolbarItem } from '../../layout/Toolbar/ToolbarItem'
+import { Button } from '../Button/Button'
+import { ButtonGroup } from '../ButtonGroup/ButtonGroup'
+import { TextField } from '../TextField/TextField'
+import { Text } from './Text'
+
+Text is a tiny component to control wrapping of text content.
+
+## Basic Usage
+
+To implement the Text component, you need to import it first:
+
+```js
+import { Text } from '@react-ui-org/react-ui';
+```
+
+And use it:
+
+<Playground>
+  <Placeholder>
+    <Text lines={3}>
+      Hello! This text will be clamped to three lines.
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+      ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+      dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+      ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+      quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget,
+      arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.
+    </Text>
+  </Placeholder>
+</Playground>
+
+See [API](#api) for all available options.
+
+## General Guidelines
+
+- Use Text anytime you need to **control potentially long strings** and
+  prevent them from overflowing or breaking their container.
+
+- **By default, Text doesn't alter rendering of its content.** Use available
+  options to achieve the result you need.
+
+- **Text renders as `<span>` by default,** so it can only contain
+  inline-level HTML elements (like `<strong>` or `<a>`, but not `<div>`, `<p>`,
+  or `<h2>`). If necessary, use the `blockLevel` option to render as `<div>` to
+  keep your HTML valid.
+
+- **Use Text for short pieces of text content.** Including a couple of HTML tags
+  shouldn't cause any harm, but keep in mind Text is not intended to wrap
+  complex HTML structures or even React components.
+
+## Number of Lines
+
+Specify how many `lines` of text should be visible if content doesn't fit its
+container. If the number of lines is exceeded, the content is truncated and
+appended by an ellipsis (`…`).
+
+<Playground>
+  {() => {
+    const [lines, setLines] = React.useState(1);
+    return (
+      <div>
+        <Toolbar align="baseline">
+          <ToolbarItem>
+            <TextField
+              changeHandler={(e) => setLines(e.target.value)}
+              label="Number of lines"
+              min={1}
+              max={100}
+              type="number"
+              value={lines}
+            />
+          </ToolbarItem>
+        </Toolbar>
+        <Placeholder>
+          <Text lines={lines}>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+            commodo ligula eget dolor. Aenean massa. Cum sociis natoque
+            penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+            Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
+            Nulla consequat massa quis enim. Donec pede justo, fringilla vel,
+            aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut,
+            imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede
+            mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum
+            semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula,
+            porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem
+            ante, dapibus in, viverra quis, feugiat a, tellus.
+          </Text>
+        </Placeholder>
+      </div>
+    );
+  }}
+</Playground>
+
+## Word Wrapping
+
+There are three possible ways of controlling wrapping of long words if they do
+not fit on a line. Set `wordWrapping` to one of the following values:
+
+- `normal`: Do not force any wrapping (default behavior).
+
+- `long-words`: To prevent overflow, an otherwise unbreakable string of
+  characters — like a long word or URL — may be broken at any point if there are
+  no otherwise-acceptable break points in the line.
+
+- `anywhere`: Create a break at the exact place where text would otherwise
+  overflow its container (even if putting an entire word on its own line would
+  negate the need for a break).
+
+📖 [Read more about wrapping and breaking text at MDN.](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Text/Wrapping_Text)
+
+### Hyphens
+
+The `hyphens` option specifies how words should be hyphenated when text wraps
+across multiple lines. It can prevent hyphenation entirely, hyphenate at
+manually-specified points within the text, or let the browser automatically
+insert hyphens where appropriate.
+
+👉 The `auto` setting's behavior depends on the language being properly tagged
+to select the appropriate hyphenation rules. **You must specify a language**
+using the `lang` HTML attribute (e.g.
+[on `<html>` tag](/getting-started/usage#full-example)) to guarantee that
+automatic hyphenation is applied in that language.
+
+👉 [Manually suggested line break opportunities](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens#suggesting_line_break_opportunities)
+will override automatic break point selection in `auto` mode when present.
+
+📖 [Read more about `hyphens` CSS property at MDN.](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens)
+
+<Playground>
+  {() => {
+    const [hyphens, setHyphens] = React.useState('none');
+    const [wordWrapping, setWordWrapping] = React.useState('normal');
+    return (
+      <div>
+        <Toolbar>
+          <ToolbarGroup align="baseline">
+            <ToolbarItem>
+              <span id="word-wrapping-options-label">Word wrapping:</span>
+            </ToolbarItem>
+            <ToolbarItem>
+              <ButtonGroup aria-labelledby="#word-wrapping-options-label">
+                <Button
+                  label="normal"
+                  clickHandler={() => setWordWrapping('normal')}
+                  color={wordWrapping === 'normal' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="long-words"
+                  clickHandler={() => setWordWrapping('long-words')}
+                  color={wordWrapping === 'long-words' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="anywhere"
+                  clickHandler={() => setWordWrapping('anywhere')}
+                  color={wordWrapping === 'anywhere' ? 'dark' : 'primary'}
+                />
+              </ButtonGroup>
+            </ToolbarItem>
+          </ToolbarGroup>
+          <ToolbarGroup align="baseline">
+            <ToolbarItem>
+              <span id="hyphens-options-label">Hyphens:</span>
+            </ToolbarItem>
+            <ToolbarItem>
+              <ButtonGroup aria-labelledby="#hyphens-options-label">
+                <Button
+                  label="none"
+                  clickHandler={() => setHyphens('none')}
+                  color={hyphens === 'none' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="auto"
+                  clickHandler={() => setHyphens('auto')}
+                  color={hyphens === 'auto' ? 'dark' : 'primary'}
+                />
+                <Button
+                  label="manual"
+                  clickHandler={() => setHyphens('manual')}
+                  color={hyphens === 'manual' ? 'dark' : 'primary'}
+                />
+              </ButtonGroup>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </Toolbar>
+        <Placeholder width="11em" bordered>
+          <Text hyphens={hyphens} wordWrapping={wordWrapping}>
+            {hyphens === 'manual'
+              ? (<>LongWord&shy;ThatHasManual&shy;Breaking&shy;Possibilities</>)
+              : (<>LongWordThatHasNoBreakingPossibilities</>)}
+            {' '}
+            and a couple of ordinary words that are nice and well behaved.
+          </Text>
+        </Placeholder>
+      </div>
+    );
+  }}
+</Playground>
+
+## API
+
+<Props table of={Text} />

--- a/src/lib/components/ui/Text/Text.jsx
+++ b/src/lib/components/ui/Text/Text.jsx
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withProviderContext } from '../../../provider';
+import getRootHyphensClassName from './helpers/getRootHyphensClassName';
+import getRootWordWrappingClassName from './helpers/getRootWordWrappingClassName';
+import styles from './Text.scss';
+
+export const Text = ({
+  blockLevel,
+  children,
+  hyphens,
+  id,
+  lines,
+  wordWrapping,
+}) => {
+  const HtmlElement = blockLevel ? 'div' : 'span';
+
+  return (
+    <HtmlElement
+      className={(hyphens !== 'none' || lines > 0 || wordWrapping !== 'normal')
+        ? [
+          (lines > 0) ? styles.rootClampLines : '',
+          getRootHyphensClassName(hyphens, styles),
+          getRootWordWrappingClassName(wordWrapping, styles),
+        ].join(' ')
+        : undefined}
+      id={id}
+      style={(lines > 0) ? { '--rui-custom-lines': lines } : undefined}
+    >
+      {children}
+    </HtmlElement>
+  );
+};
+
+Text.defaultProps = {
+  blockLevel: false,
+  children: null,
+  hyphens: 'none',
+  id: undefined,
+  lines: undefined,
+  wordWrapping: 'normal',
+};
+
+Text.propTypes = {
+  /**
+   * If true, the root HTML element renders as `<div>` instead of `<span>`.
+   */
+  blockLevel: PropTypes.bool,
+  /**
+   * Text content to be sanitized. Can contain HTML.
+   */
+  children: PropTypes.node,
+  /**
+   * Turn on hyphenation. Head to [Hyphens](#hyphens) to learn more.
+   */
+  hyphens: PropTypes.oneOf(['none', 'auto', 'manual']),
+  /**
+   * Optional ID of the root HTML element.
+   */
+  id: PropTypes.string,
+  /**
+   * Optional number of lines. If exceeded, the content is truncated and appended by an ellipsis (`…`).
+   */
+  lines: PropTypes.number,
+  /**
+   * How to deal with long words. Head to [Word Wrapping](#word-wrapping) for detailed explanation.
+   */
+  wordWrapping: PropTypes.oneOf(['normal', 'long-words', 'anywhere']),
+};
+
+export const TextWithContext = withProviderContext(Text, 'Text');
+
+export default TextWithContext;

--- a/src/lib/components/ui/Text/Text.scss
+++ b/src/lib/components/ui/Text/Text.scss
@@ -1,0 +1,30 @@
+// 1. `word-break: break-word` is deprecated in favour of `overflow-wrap: anywhere`, but it's still
+//     required for Safari.
+//     https://caniuse.com/mdn-css_properties_overflow-wrap_anywhere
+
+/* stylelint-disable property-no-vendor-prefix, value-no-vendor-prefix */
+.rootClampLines {
+  display: -webkit-box;
+  -webkit-line-clamp: var(--rui-custom-lines);
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* stylelint-enable property-no-vendor-prefix, value-no-vendor-prefix */
+
+.rootHyphensAuto {
+  hyphens: auto;
+}
+
+.rootHyphensManual {
+  hyphens: manual;
+}
+
+.rootWordWrappingAnywhere {
+  word-break: break-all;
+}
+
+.rootWordWrappingLongWords {
+  word-break: break-word; // 1.
+  overflow-wrap: anywhere;
+}

--- a/src/lib/components/ui/Text/__tests__/Text.test.jsx
+++ b/src/lib/components/ui/Text/__tests__/Text.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Text } from '../Text';
+
+describe('rendering', () => {
+  it('renders correctly with no props', () => {
+    const tree = shallow(
+      <Text>
+        test
+      </Text>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly as div', () => {
+    const tree = shallow(
+      <Text blockLevel>
+        test
+      </Text>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with word wrapping', () => {
+    const tree = shallow(
+      <Text wordWrapping="long-words">
+        test
+      </Text>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with line clamp', () => {
+    const tree = shallow(
+      <Text lines={2}>
+        test
+      </Text>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/ui/Text/__tests__/__snapshots__/Text.test.jsx.snap
+++ b/src/lib/components/ui/Text/__tests__/__snapshots__/Text.test.jsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering renders correctly as div 1`] = `
+<div>
+  test
+</div>
+`;
+
+exports[`rendering renders correctly with line clamp 1`] = `
+<span
+  className="rootClampLines  "
+  style={
+    Object {
+      "--rui-custom-lines": 2,
+    }
+  }
+>
+  test
+</span>
+`;
+
+exports[`rendering renders correctly with no props 1`] = `
+<span>
+  test
+</span>
+`;
+
+exports[`rendering renders correctly with word wrapping 1`] = `
+<span
+  className="  rootWordWrappingLongWords"
+>
+  test
+</span>
+`;

--- a/src/lib/components/ui/Text/helpers/getRootHyphensClassName.js
+++ b/src/lib/components/ui/Text/helpers/getRootHyphensClassName.js
@@ -1,0 +1,11 @@
+export default (hyphens, styles) => {
+  if (hyphens === 'auto') {
+    return styles.rootHyphensAuto;
+  }
+
+  if (hyphens === 'manual') {
+    return styles.rootHyphensManual;
+  }
+
+  return null;
+};

--- a/src/lib/components/ui/Text/helpers/getRootWordWrappingClassName.js
+++ b/src/lib/components/ui/Text/helpers/getRootWordWrappingClassName.js
@@ -1,0 +1,11 @@
+export default (wordWrapping, styles) => {
+  if (wordWrapping === 'anywhere') {
+    return styles.rootWordWrappingAnywhere;
+  }
+
+  if (wordWrapping === 'long-words') {
+    return styles.rootWordWrappingLongWords;
+  }
+
+  return null;
+};

--- a/src/lib/components/ui/Text/index.js
+++ b/src/lib/components/ui/Text/index.js
@@ -1,0 +1,1 @@
+export { default } from './Text';

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -47,6 +47,7 @@ export { default as Radio } from './components/ui/Radio';
 export { default as ScrollView } from './components/ui/ScrollView';
 export { default as SelectField } from './components/ui/SelectField';
 export { default as Table } from './components/ui/Table';
+export { default as Text } from './components/ui/Text';
 export { default as TextArea } from './components/ui/TextArea';
 export { default as TextField } from './components/ui/TextField';
 export { default as Toggle } from './components/ui/Toggle';


### PR DESCRIPTION
<img width="862" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/123709894-15e0fa80-d86e-11eb-80d9-9cec6a3132b8.png">

---

<img width="867" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/123709966-2beebb00-d86e-11eb-99e0-ff60735d9f57.png">

Closes #286.