### PR TITLE
Unify and improve API tables in docs

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -112,11 +112,9 @@ export default {
     showPlaygroundEditor: false,
     styles: {
       Container: {
-        '& > table': {
-          fontSize: 'smaller',
-        },
         '& [data-testid="live-preview"]': {
           fontSize: '1rem', // Set the font size in playground to override the docs theme default.
+          overflow: 'auto', // Make preview scrollable.
           p: 3,
         },
         '& [data-testid="live-preview"] * ul': { // Reset lists in components.
@@ -197,6 +195,25 @@ export default {
         },
         px: 4,
         py: 6,
+        table: {
+          fontSize: 'var(--rui-typography-size-0)',
+          minWidth: '0 !important',
+        },
+        'table tbody td:first-child': {
+          fontWeight: 'bold', // Emphasize prop names.
+        },
+        'table tbody td:first-child code': {
+          fontWeight: 'initial', // Revert previously set emphasize for custom property names.
+        },
+        'table tbody td:nth-child(2) code': {
+          whiteSpace: 'pre', // Preserve formatting for prop types.
+        },
+        'table td p:not(:last-child)': {
+          mb: 3,
+        },
+        'table ul, table ol': {
+          ml: 1,
+        },
         ul: {
           ml: 5,
         },


### PR DESCRIPTION
**Before:**

<img width="890" alt="image" src="https://user-images.githubusercontent.com/5614085/137559235-03e9e059-20d6-42f1-9380-d77ed8920795.png">

<img width="465" alt="image" src="https://user-images.githubusercontent.com/5614085/137559315-529a67ff-7c68-4321-9c2a-ef9c2daa5e80.png">

**After:**

<img width="873" alt="image" src="https://user-images.githubusercontent.com/5614085/137559263-2ca229ba-d426-4d68-a9d0-7ac538e6bb43.png">

<img width="492" alt="image" src="https://user-images.githubusercontent.com/5614085/137559328-d6ee0e4b-78cb-48ac-98e4-e957c419fa1e.png">