### PR TITLE
Extend `Paper` with a new `muted` property (#316)

### DIFF
--- a/src/lib/components/ui/Paper/Paper.jsx
+++ b/src/lib/components/ui/Paper/Paper.jsx
@@ -6,11 +6,13 @@ import styles from './Paper.scss';
 export const Paper = ({
   children,
   id,
+  muted,
   raised,
 }) => (
   <div
     className={[
       styles.root,
+      muted ? styles.rootMuted : '',
       raised ? styles.rootRaised : '',
     ].join(' ')}
     id={id}
@@ -22,6 +24,7 @@ export const Paper = ({
 Paper.defaultProps = {
   children: null,
   id: undefined,
+  muted: false,
   raised: false,
 };
 
@@ -34,6 +37,10 @@ Paper.propTypes = {
    * ID of the root HTML element.
    */
   id: PropTypes.string,
+  /**
+   * Visually suppress Paper.
+   */
+  muted: PropTypes.bool,
   /**
    * Add shadow to pull the Paper above surface.
    */

--- a/src/lib/components/ui/Paper/Paper.scss
+++ b/src/lib/components/ui/Paper/Paper.scss
@@ -7,6 +7,11 @@
   background-color: theme.$background-color;
 }
 
+.rootMuted {
+  background-color: theme.$muted-background-color;
+  opacity: theme.$muted-opacity;
+}
+
 .rootRaised {
   box-shadow: theme.$raised-box-shadow;
 }

--- a/src/lib/components/ui/Paper/README.mdx
+++ b/src/lib/components/ui/Paper/README.mdx
@@ -53,6 +53,16 @@ Add optional shadow to lift the paper above background.
   </Paper>
 </Playground>
 
+## Muted Paper
+
+Dim background and add transparency to visually suppress the Paper.
+
+<Playground>
+  <Paper muted>
+    Sssh! I&apos;m paper and I&apos;m muted.
+  </Paper>
+</Playground>
+
 ## API
 
 <Props table of={Paper} />
@@ -66,4 +76,6 @@ Add optional shadow to lift the paper above background.
 | `--rui-Paper__border-color`                          | Border color                                                 |
 | `--rui-Paper__border-radius`                         | Corner radius                                                |
 | `--rui-Paper__background-color`                      | Paper background color                                       |
+| `--rui-Paper--muted__background-color`               | Background color of muted paper                              |
+| `--rui-Paper--muted__opacity`                        | Opacity of muted paper                                       |
 | `--rui-Paper--raised__box-shadow`                    | Box shadow of raised paper                                   |

--- a/src/lib/components/ui/Paper/__tests__/Paper.test.jsx
+++ b/src/lib/components/ui/Paper/__tests__/Paper.test.jsx
@@ -18,6 +18,14 @@ describe('rendering', () => {
       (rootElement) => expect(rootElement).toBeInTheDocument(),
     ],
     ...idPropTest,
+    [
+      { muted: true },
+      (rootElement) => expect(rootElement).toHaveClass('rootMuted'),
+    ],
+    [
+      { muted: false },
+      (rootElement) => expect(rootElement).not.toHaveClass('rootMuted'),
+    ],
     ...raisedPropTest,
   ])('renders with props: "%s"', (testedProps, assert) => {
     const dom = render((

--- a/src/lib/components/ui/Paper/_theme.scss
+++ b/src/lib/components/ui/Paper/_theme.scss
@@ -3,4 +3,6 @@ $border-width: var(--rui-Paper__border-width);
 $border-color: var(--rui-Paper__border-color);
 $border-radius: var(--rui-Paper__border-radius);
 $background-color: var(--rui-Paper__background-color);
+$muted-background-color: var(--rui-Paper--muted__background-color);
+$muted-opacity: var(--rui-Paper--muted__opacity);
 $raised-box-shadow: var(--rui-Paper--raised__box-shadow);

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -155,6 +155,11 @@
   --rui-spacing-bottom-headings: var(--rui-spacing-5);
   --rui-spacing-bottom-layouts: var(--rui-spacing-5);
 
+  // Disabled state
+  --rui-disabled-background-color: var(--rui-color-gray-50);
+  --rui-disabled-opacity: 0.5;
+  --rui-disabled-cursor: not-allowed;
+
   //
   // Elements
   // ========
@@ -292,8 +297,8 @@
   --rui-Button__text-transform: none;
   --rui-Button__border-width: var(--rui-border-width);
   --rui-Button__border-radius: var(--rui-border-radius);
-  --rui-Button--disabled__opacity: 0.5;
-  --rui-Button--disabled__cursor: not-allowed;
+  --rui-Button--disabled__opacity: var(--rui-disabled-opacity);
+  --rui-Button--disabled__cursor: var(--rui-disabled-cursor);
 
   // Buttons: filled priority
 
@@ -674,8 +679,8 @@
   --rui-Card__border-radius: var(--rui-border-radius);
   --rui-Card--dense__padding: var(--rui-spacing-2);
   --rui-Card--raised__box-shadow: var(--rui-elevation-1);
-  --rui-Card--disabled__background-color: var(--rui-color-gray-50);
-  --rui-Card--disabled__opacity: 0.6;
+  --rui-Card--disabled__background-color: var(--rui-disabled-background-color);
+  --rui-Card--disabled__opacity: var(--rui-disabled-opacity);
 
   // Card: variant: primary
   --rui-Card--primary__color: var(--rui-page-color);
@@ -758,8 +763,8 @@
   --rui-FormField--horizontal--full-width__label__width: fit-content(50%);
 
   // Forms fields: disabled state
-  --rui-FormField--disabled__cursor: not-allowed;
-  --rui-FormField--disabled__opacity: 0.5;
+  --rui-FormField--disabled__cursor: var(--rui-disabled-cursor);
+  --rui-FormField--disabled__opacity: var(--rui-disabled-opacity);
 
   // Form fields: validation states: invalid
   --rui-FormField--invalid--default__border-color: var(--rui-color-danger);
@@ -878,6 +883,8 @@
   --rui-Paper__border-color: transparent;
   --rui-Paper__border-radius: var(--rui-border-radius);
   --rui-Paper__background-color: var(--rui-color-white);
+  --rui-Paper--muted__background-color: var(--rui-disabled-background-color);
+  --rui-Paper--muted__opacity: var(--rui-disabled-opacity);
   --rui-Paper--raised__box-shadow: var(--rui-elevation-1);
 
   //


### PR DESCRIPTION
<img width="872" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/138757331-53101841-317d-4a0b-8553-0045cc9419bd.png">

Closes #316.