### PR TITLE
Replace `Button` loading state with a more flexible and newly designed feedback state

### DIFF
--- a/src/lib/components/ui/Button/Button.jsx
+++ b/src/lib/components/ui/Button/Button.jsx
@@ -18,11 +18,11 @@ export const Button = ({
   clickHandler,
   disabled,
   endCorner,
+  feedbackIcon,
   forwardedRef,
   id,
   label,
   labelVisibility,
-  loadingIcon,
   priority,
   size,
   startCorner,
@@ -51,9 +51,9 @@ export const Button = ({
         getRootLabelVisibilityClassName(labelVisibility, styles),
         resolveContextOrProp(context && context.block, block) ? styles.rootBlock : '',
         context ? styles.rootGrouped : '',
-        loadingIcon ? styles.isRootLoading : '',
+        feedbackIcon ? styles.hasRootFeedback : '',
       ].join(' ')}
-      disabled={resolveContextOrProp(context && context.disabled, disabled) || !!loadingIcon}
+      disabled={resolveContextOrProp(context && context.disabled, disabled) || !!feedbackIcon}
       id={id}
       onClick={clickHandler}
       ref={forwardedRef}
@@ -85,9 +85,9 @@ export const Button = ({
           {endCorner}
         </span>
       )}
-      {loadingIcon && (
-        <span className={styles.loadingIcon}>
-          {loadingIcon}
+      {feedbackIcon && (
+        <span className={styles.feedbackIcon}>
+          {feedbackIcon}
         </span>
       )}
     </button>
@@ -103,10 +103,10 @@ Button.defaultProps = {
   color: 'primary',
   disabled: false,
   endCorner: null,
+  feedbackIcon: null,
   forwardedRef: undefined,
   id: undefined,
   labelVisibility: 'all',
-  loadingIcon: null,
   priority: 'filled',
   size: 'medium',
   startCorner: null,
@@ -149,6 +149,11 @@ Button.propTypes = {
    */
   endCorner: PropTypes.node,
   /**
+   * Element to be displayed as a feedback icon on top of button label. When defined, it implies the
+   * button is in feedback state.
+   */
+  feedbackIcon: PropTypes.node,
+  /**
    * Reference forwarded to the `button` element.
    */
   forwardedRef: PropTypes.oneOfType([
@@ -171,11 +176,6 @@ Button.propTypes = {
    * Defines when the button label should be visible.
    */
   labelVisibility: PropTypes.oneOf(['all', 'desktop', 'none']),
-  /**
-   * Element to be displayed as a loading icon. When defined, it implies the button is in the
-   * loading state.
-   */
-  loadingIcon: PropTypes.node,
   /**
    * Visual priority to highlight or suppress the button.
    *

--- a/src/lib/components/ui/Button/README.mdx
+++ b/src/lib/components/ui/Button/README.mdx
@@ -233,46 +233,127 @@ Disabled state makes the action unavailable.
   <Button label="Disabled flat button" priority="flat" disabled />
 </Playground>
 
-### Loading State
+### Feedback State
 
-When an action triggers an asynchronous process on background, the button's
-loading state can be indicated by showing a loading icon. Buttons in loading
-state are automatically made disabled to prevent unwanted interaction.
+When user's action triggers an asynchronous process on background, the button's
+feedback state can be indicated by showing an icon. The icon replaces button's
+label while retaining original dimensions of the button. Buttons in feedback
+state are automatically disabled to prevent unwanted interaction.
+
+Filled buttons in feedback state:
 
 <Playground>
   <Button
-    label="Button in loading state"
-    loadingIcon={(
-      <span className="d-inline-flex animation-spin-counterclockwise">
-        <Icon icon="loading" />
-      </span>
-    )}
+    label="Success"
+    color="success"
+    feedbackIcon={<Icon icon="success" />}
   />
   <Button
-    label="Icon button in loading state"
+    label="Success"
     labelVisibility="none"
-    beforeLabel={<Icon icon="pencil" />}
-    loadingIcon={(
+    color="success"
+    feedbackIcon={<Icon icon="success" />}
+    endCorner={<Badge color="danger" label={3} />}
+  />
+  <Placeholder dark inline>
+    <Button
+      label="Light"
+      color="light"
+      feedbackIcon={<Icon icon="success" />}
+    />
+  </Placeholder>
+  <Button
+    label="Dark"
+    color="dark"
+    feedbackIcon={<Icon icon="success" />}
+  />
+  <Button
+    label="Primary"
+    feedbackIcon={(
       <span className="d-inline-flex animation-spin-counterclockwise">
         <Icon icon="loading" />
       </span>
     )}
   />
+</Playground>
+
+Outline buttons in feedback state:
+
+<Playground>
   <Button
-    label="Icon button with badge, loading"
-    labelVisibility="desktop"
-    beforeLabel={<Icon icon="pencil" />}
-    loadingIcon={(
+    label="Success"
+    priority="outline"
+    color="success"
+    feedbackIcon={<Icon icon="success" />}
+  />
+  <Button
+    label="Success"
+    labelVisibility="none"
+    priority="outline"
+    color="success"
+    feedbackIcon={<Icon icon="success" />}
+    endCorner={<Badge color="danger" label={3} />}
+  />
+  <Placeholder dark inline>
+    <Button
+      label="Light"
+      priority="outline"
+      color="light"
+      feedbackIcon={<Icon icon="success" />}
+    />
+  </Placeholder>
+  <Button
+    label="Dark"
+    priority="outline"
+    color="dark"
+    feedbackIcon={<Icon icon="success" />}
+  />
+  <Button
+    label="Primary"
+    priority="outline"
+    feedbackIcon={(
       <span className="d-inline-flex animation-spin-counterclockwise">
         <Icon icon="loading" />
       </span>
     )}
-    startCorner={<Badge label={3} color="danger" />}
+  />
+</Playground>
+
+Flat buttons in feedback state:
+
+<Playground>
+  <Button
+    label="Success"
+    priority="flat"
+    color="success"
+    feedbackIcon={<Icon icon="success" />}
   />
   <Button
-    label="Icon after label, loading"
-    afterLabel={<Icon icon="up" />}
-    loadingIcon={(
+    label="Success"
+    labelVisibility="none"
+    priority="flat"
+    color="success"
+    feedbackIcon={<Icon icon="success" />}
+    endCorner={<Badge color="danger" label={3} />}
+  />
+  <Placeholder dark inline>
+    <Button
+      label="Light"
+      priority="flat"
+      color="light"
+      feedbackIcon={<Icon icon="success" />}
+    />
+  </Placeholder>
+  <Button
+    label="Dark"
+    priority="flat"
+    color="dark"
+    feedbackIcon={<Icon icon="success" />}
+  />
+  <Button
+    label="Primary"
+    priority="flat"
+    feedbackIcon={(
       <span className="d-inline-flex animation-spin-counterclockwise">
         <Icon icon="loading" />
       </span>
@@ -430,3 +511,13 @@ Example:
     />
   </div>
 </Playground>
+
+### Theming Feedback State
+
+Similarly to disabled state, opacity and cursor can be set for buttons in
+feedback state.
+
+| Custom Property                   | Description                                          |
+|-----------------------------------|------------------------------------------------------|
+| `--rui-Button--feedback__opacity` | Opacity of buttons in feedback state                 |
+| `--rui-Button--feedback__cursor`  | Cursor to show on hovering buttons in feedback state |

--- a/src/lib/components/ui/Button/__tests__/Button.test.jsx
+++ b/src/lib/components/ui/Button/__tests__/Button.test.jsx
@@ -117,10 +117,11 @@ describe('rendering', () => {
       (rootElement) => expect(rootElement).toHaveClass('withLabelHidden'),
     ],
     [
-      { loadingIcon: <div>loading icon</div> },
+      { feedbackIcon: <div>feedback icon</div> },
       (rootElement) => {
-        expect(within(rootElement).getByText('loading icon'));
+        expect(within(rootElement).getByText('feedback icon'));
         expect(rootElement).toBeDisabled();
+        expect(rootElement).toHaveClass('hasRootFeedback');
       },
     ],
     [

--- a/src/lib/components/ui/Button/_base.scss
+++ b/src/lib/components/ui/Button/_base.scss
@@ -17,25 +17,17 @@
 .afterLabel,
 .startCorner,
 .endCorner,
-.loadingIcon {
+.feedbackIcon {
   display: flex;
   align-items: baseline;
   justify-content: center;
-}
-
-.beforeLabel {
-  margin-right: settings.$icon-spacing;
-}
-
-.afterLabel,
-.loadingIcon {
-  margin-left: settings.$icon-spacing;
 }
 
 .startCorner,
 .endCorner {
   position: absolute;
   top: -0.35rem;
+  z-index: 2;
 }
 
 .startCorner {
@@ -46,6 +38,16 @@
 .endCorner {
   right: 0;
   margin-right: -0.35rem;
+}
+
+.feedbackIcon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  align-items: center;
 }
 
 .rootSizeSmall {
@@ -68,6 +70,17 @@
   @include breakpoint.up(settings.$breakpoint) {
     width: 100%;
   }
+}
+
+.hasRootFeedback:disabled {
+  opacity: theme.$feedback-opacity;
+  cursor: theme.$feedback-cursor;
+}
+
+.hasRootFeedback .label,
+.hasRootFeedback .beforeLabel,
+.hasRootFeedback .afterLabel {
+  color: transparent;
 }
 
 .rootGrouped {
@@ -108,31 +121,6 @@
   }
 }
 
-.withLabelHidden .beforeLabel,
-.withLabelHidden .afterLabel,
-.withLabelHiddenMobile .beforeLabel,
-.withLabelHiddenMobile .afterLabel {
-  margin-right: 0;
-  margin-left: 0;
-}
-
-.withLabelHiddenMobile .beforeLabel {
-  @include breakpoint.up(settings.$breakpoint) {
-    margin-right: settings.$icon-spacing;
-  }
-}
-
-.withLabelHiddenMobile .afterLabel {
-  @include breakpoint.up(settings.$breakpoint) {
-    margin-left: settings.$icon-spacing;
-  }
-}
-
-.withLabelHidden.isRootLoading .loadingIcon,
-.withLabelHiddenMobile.isRootLoading .loadingIcon {
-  margin-left: 0;
-}
-
 .withLabelHidden.isRootLoading .beforeLabel,
 .withLabelHidden.isRootLoading .afterLabel,
 .withLabelHiddenMobile.isRootLoading .beforeLabel,
@@ -144,11 +132,5 @@
 .withLabelHiddenMobile.isRootLoading .afterLabel {
   @include breakpoint.up(settings.$breakpoint) {
     display: flex;
-  }
-}
-
-.withLabelHiddenMobile.isRootLoading .loadingIcon {
-  @include breakpoint.up(settings.$breakpoint) {
-    margin-left: settings.$icon-spacing;
   }
 }

--- a/src/lib/components/ui/Button/_theme.scss
+++ b/src/lib/components/ui/Button/_theme.scss
@@ -6,8 +6,11 @@ $letter-spacing: var(--rui-Button__letter-spacing);
 $text-transform: var(--rui-Button__text-transform);
 $border-width: var(--rui-Button__border-width);
 $border-radius: var(--rui-Button__border-radius);
+
 $disabled-opacity: var(--rui-Button--disabled__opacity);
 $disabled-cursor: var(--rui-Button--disabled__cursor);
+$feedback-opacity: var(--rui-Button--feedback__opacity);
+$feedback-cursor: var(--rui-Button--feedback__cursor);
 
 $group-filled-gap: var(--rui-ButtonGroup--filled__gap);
 $group-filled-separator-width: var(--rui-ButtonGroup--filled__separator__width);

--- a/src/lib/components/ui/Button/_tools.scss
+++ b/src/lib/components/ui/Button/_tools.scss
@@ -63,6 +63,7 @@
 
   position: relative; // 3.
   display: inline-flex;
+  column-gap: settings.$icon-spacing;
   align-items: center;
   justify-content: center;
   width: var(--rui-local-width, auto);

--- a/src/lib/components/ui/ButtonGroup/README.mdx
+++ b/src/lib/components/ui/ButtonGroup/README.mdx
@@ -12,6 +12,7 @@ import {
   Playground,
   Props,
 } from 'docz'
+import Icon from '../../../../docs/_components/Icon'
 import Button from '../Button'
 import { ButtonGroup } from './ButtonGroup'
 
@@ -161,6 +162,29 @@ Disables all buttons inside the group.
   </ButtonGroup>
   <ButtonGroup priority="flat" disabled>
     <Button label="Week" />
+    <Button label="Month" />
+    <Button label="Year" />
+  </ButtonGroup>
+</Playground>
+
+### Feedback State
+
+When user's action triggers an asynchronous process on background, feedback
+state of individual buttons can be indicated by showing an icon.
+
+<Playground>
+  <ButtonGroup>
+    <Button label="Week" color="success" feedbackIcon={<Icon icon="success" />} />
+    <Button label="Month" />
+    <Button label="Year" />
+  </ButtonGroup>
+  <ButtonGroup priority="outline">
+    <Button label="Week" color="success" feedbackIcon={<Icon icon="success" />} />
+    <Button label="Month" />
+    <Button label="Year" />
+  </ButtonGroup>
+  <ButtonGroup priority="flat">
+    <Button label="Week" color="success" feedbackIcon={<Icon icon="success" />} />
     <Button label="Month" />
     <Button label="Year" />
   </ButtonGroup>

--- a/src/lib/components/ui/Modal/Modal.jsx
+++ b/src/lib/components/ui/Modal/Modal.jsx
@@ -194,9 +194,9 @@ export class Modal extends React.Component {
                       clickHandler={action.clickHandler}
                       color={action.color}
                       disabled={action.disabled}
+                      feedbackIcon={action.feedbackIcon}
                       id={action.id || undefined}
                       label={action.label}
-                      loadingIcon={action.loadingIcon}
                       forwardedRef={this.submitButtonRef}
                       type="button"
                     />
@@ -254,9 +254,9 @@ Modal.propTypes = {
     clickHandler: PropTypes.func.isRequired,
     color: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger', 'help', 'info', 'note', 'light', 'dark']),
     disabled: PropTypes.bool,
+    feedbackIcon: PropTypes.node,
     id: PropTypes.string,
     label: PropTypes.string.isRequired,
-    loadingIcon: PropTypes.node,
   })),
   /**
    * If `true`, focus the first action in the footer when the modal is opened.

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -299,6 +299,8 @@
   --rui-Button__border-radius: var(--rui-border-radius);
   --rui-Button--disabled__opacity: var(--rui-disabled-opacity);
   --rui-Button--disabled__cursor: var(--rui-disabled-cursor);
+  --rui-Button--feedback__opacity: 1;
+  --rui-Button--feedback__cursor: var(--rui-disabled-cursor);
 
   // Buttons: filled priority
 


### PR DESCRIPTION
## Before

<img width="874" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/138968190-429ee4de-0d85-4216-a739-ac899491e600.png">

## After

<img width="850" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/138967784-1ba24aa8-5f43-430d-990d-3a37719e5aa7.png">

<img width="862" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/138968073-006eafe2-6e8c-431d-9acf-2cbca83916ef.png">

<img width="851" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/138968110-bfde529e-87fa-4e09-9cf1-5803abe5bee2.png">
