### PR TITLE
Change naming of event handlers from `<event>Handler` to `on<Event>` and remove unnecessary event handlers such as `onClick` and `onChange` which are passed into the native elements directly using `transferProps` mechanism (#218)

### DIFF
--- a/src/docs/customize/global-props.mdx
+++ b/src/docs/customize/global-props.mdx
@@ -66,9 +66,9 @@ See working example:
         <Toolbar align="bottom">
           <ToolbarItem>
             <SelectField
-              changeHandler={(e) => setVariant(e.target.value)}
               id="variant"
               label="Select variant of Select Field"
+              onChange={(e) => setVariant(e.target.value)}
               options={[
                 {
                   label: 'filled',
@@ -90,7 +90,6 @@ See working example:
           </ToolbarItem>
           <ToolbarItem>
             <Button
-              clickHandler={() => {}}
               id="my-button"
               label="Button"
             />

--- a/src/docs/customize/theming/forms.mdx
+++ b/src/docs/customize/theming/forms.mdx
@@ -109,9 +109,9 @@ Example:
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           id="default-outline-select-field"
           label="Default outline select field"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
@@ -126,9 +126,9 @@ Example:
             variant="filled"
           />
           <SelectField
-            changeHandler={(e) => setFruit(e.target.value)}
             id="themed-outline-select-field"
             label="Themed outline select field"
+            onChange={(e) => setFruit(e.target.value)}
             options={options}
             value={fruit}
           />
@@ -191,9 +191,9 @@ Example:
           label="Default outline text field"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           id="default-outline-select-field"
           label="Default outline select field"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
@@ -203,9 +203,9 @@ Example:
             label="Themed outline text field"
           />
           <SelectField
-            changeHandler={(e) => setFruit(e.target.value)}
             id="themed-outline-select-field"
             label="Themed outline select field"
+            onChange={(e) => setFruit(e.target.value)}
             options={options}
             value={fruit}
           />
@@ -260,9 +260,9 @@ Example:
           label="Default medium text field"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           id="default-medium-select-field"
           label="Default medium select field"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
@@ -272,9 +272,9 @@ Example:
             label="Themed medium text field"
           />
           <SelectField
-            changeHandler={(e) => setFruit(e.target.value)}
             id="themed-medium-select-field"
             label="Themed medium select field"
+            onChange={(e) => setFruit(e.target.value)}
             options={options}
             value={fruit}
           />
@@ -329,9 +329,9 @@ Example:
           `}
         </style>
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           id="default-radio"
           label="Default radio"
+          onChange={(e) => setFruit(e.target.value)}
           options={[
             {
               label: 'Apple',
@@ -349,22 +349,22 @@ Example:
           value={fruit}
         />
         <CheckboxField
-          changeHandler={() => setAgree(!agree)}
           checked={agree}
           id="default-checkbox"
           label="Default checkbox"
+          onChange={() => setAgree(!agree)}
         />
         <Toggle
-          changeHandler={() => setStudioQuality(!studioQuality)}
           checked={studioQuality}
           id="default-toggle"
           label="Default toggle"
+          onChange={() => setStudioQuality(!studioQuality)}
         />
         <div className="example example--themed-check-fields mt-6">
           <Radio
-            changeHandler={(e) => setFruit(e.target.value)}
             id="themed-radio"
             label="Themed radio"
+            onChange={(e) => setFruit(e.target.value)}
             options={[
               {
                 label: 'Apple',
@@ -382,16 +382,16 @@ Example:
             value={fruit}
           />
           <CheckboxField
-            changeHandler={() => setAgree(!agree)}
             checked={agree}
             id="themed-checkbox"
             label="Themed checkbox"
+            onChange={() => setAgree(!agree)}
           />
           <Toggle
-            changeHandler={() => setStudioQuality(!studioQuality)}
             checked={studioQuality}
             id="themed-toggle"
             label="Themed toggle"
+            onChange={() => setStudioQuality(!studioQuality)}
           />
         </div>
       </>
@@ -462,18 +462,18 @@ Example:
           validationText="This field is valid"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           id="default-valid-select-field"
           label="Default valid select field"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           validationState="valid"
           validationText="This field is valid"
           value={fruit}
         />
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           id="default-valid-radio"
           label="Default valid radio"
+          onChange={(e) => setFruit(e.target.value)}
           options={[
             {
               label: 'Apple',
@@ -493,18 +493,18 @@ Example:
           value={fruit}
         />
         <CheckboxField
-          changeHandler={() => setAgree(!agree)}
           checked={agree}
           id="default-valid-checkbox"
           label="Default valid checkbox"
+          onChange={() => setAgree(!agree)}
           validationState="valid"
           validationText="This field is valid"
         />
         <Toggle
-          changeHandler={() => setStudioQuality(!studioQuality)}
           checked={studioQuality}
           id="default-valid-toggle"
           label="Default valid toggle"
+          onChange={() => setStudioQuality(!studioQuality)}
           validationState="valid"
           validationText="This field is valid"
         />
@@ -516,18 +516,18 @@ Example:
             validationText="This field is valid"
           />
           <SelectField
-            changeHandler={(e) => setFruit(e.target.value)}
             id="themed-valid-select-field"
             label="Themed valid select field"
+            onChange={(e) => setFruit(e.target.value)}
             options={options}
             validationState="valid"
             validationText="This field is valid"
             value={fruit}
           />
           <Radio
-            changeHandler={(e) => setFruit(e.target.value)}
             id="themed-valid-radio"
             label="Themed valid radio"
+            onChange={(e) => setFruit(e.target.value)}
             options={[
               {
                 label: 'Apple',
@@ -547,15 +547,15 @@ Example:
             value={fruit}
           />
           <CheckboxField
-            changeHandler={() => setAgree(!agree)}
             checked={agree}
             id="themed-valid-checkbox"
             label="Themed valid checkbox"
+            onChange={() => setAgree(!agree)}
             validationState="valid"
             validationText="This field is valid"
           />
           <Toggle
-            changeHandler={() => setStudioQuality(!studioQuality)}
+            onChange={() => setStudioQuality(!studioQuality)}
             checked={studioQuality}
             id="themed-valid-toggle"
             label="Themed valid toggle"
@@ -655,7 +655,6 @@ Example:
           label="Default disabled text field"
         />
         <SelectField
-          changeHandler={() => {}}
           disabled
           id="default-disabled-select-field"
           label="Default disabled select field"
@@ -669,7 +668,6 @@ Example:
           validationState="invalid"
         />
         <Radio
-          changeHandler={() => {}}
           disabled
           id="default-disabled-radio"
           label="Default disabled radio"
@@ -690,28 +688,24 @@ Example:
           value="apple"
         />
         <CheckboxField
-          changeHandler={() => {}}
           checked
           disabled
           id="default-disabled-checkbox"
           label="Default disabled checkbox"
         />
         <Toggle
-          changeHandler={() => {}}
           checked
           disabled
           id="default-disabled-toggle"
           label="Default disabled toggle"
         />
         <CheckboxField
-          changeHandler={() => {}}
           disabled
           id="default-disabled-warning-checkbox"
           label="Default disabled warning checkbox"
           validationState="warning"
         />
         <Toggle
-          changeHandler={() => {}}
           checked
           disabled
           id="default-disabled-valid-toggle"
@@ -725,7 +719,6 @@ Example:
             label="Themed disabled text field"
           />
           <SelectField
-            changeHandler={() => {}}
             disabled
             id="themed-disabled-select-field"
             label="Themed disabled select field"
@@ -739,7 +732,6 @@ Example:
             validationState="invalid"
           />
           <Radio
-            changeHandler={() => {}}
             disabled
             id="themed-disabled-radio"
             label="Themed disabled radio"
@@ -760,28 +752,24 @@ Example:
             value="apple"
           />
           <CheckboxField
-            changeHandler={() => {}}
             checked
             disabled
             id="themed-disabled-checkbox"
             label="Themed disabled checkbox"
           />
           <Toggle
-            changeHandler={() => {}}
             checked
             disabled
             id="themed-disabled-toggle"
             label="Themed disabled toggle"
           />
           <CheckboxField
-            changeHandler={() => {}}
             disabled
             id="themed-disabled-warning-checkbox"
             label="Themed disabled warning checkbox"
             validationState="warning"
           />
           <Toggle
-            changeHandler={() => {}}
             checked
             disabled
             id="themed-disabled-valid-toggle"

--- a/src/lib/components/layout/FormLayout/README.mdx
+++ b/src/lib/components/layout/FormLayout/README.mdx
@@ -150,37 +150,35 @@ with CSS custom properties.
           <ToolbarItem>
             <ButtonGroup aria-labelledby="#label-width-options-label">
               <Button
-                label="default"
-                clickHandler={() => setLabelWidth('default')}
                 color={labelWidth === 'default' ? 'dark' : 'primary'}
+                label="default"
+                onClick={() => setLabelWidth('default')}
               />
               <Button
-                label="auto"
-                clickHandler={() => setLabelWidth('auto')}
                 color={labelWidth === 'auto' ? 'dark' : 'primary'}
+                label="auto"
+                onClick={() => setLabelWidth('auto')}
               />
               <Button
-                label="limited"
-                clickHandler={() => setLabelWidth('limited')}
                 color={labelWidth === 'limited' ? 'dark' : 'primary'}
+                label="limited"
+                onClick={() => setLabelWidth('limited')}
               />
               <Button
-                label="custom"
-                clickHandler={() => setLabelWidth('custom')}
                 color={labelWidth === 'custom' ? 'dark' : 'primary'}
+                label="custom"
+                onClick={() => setLabelWidth('custom')}
               />
             </ButtonGroup>
           </ToolbarItem>
           {labelWidth === 'custom' && (
             <ToolbarItem>
               <TextField
-                changeHandler={(e) => (
-                  setCustomLabelWidth(e.target.value)
-                )}
                 inputSize={5}
                 isLabelVisible={false}
                 label="Custom label width"
                 layout="horizontal"
+                onChange={(e) => setCustomLabelWidth(e.target.value)}
                 value={customLabelWidth}
               />
             </ToolbarItem>
@@ -340,9 +338,9 @@ properly vertically aligned.
             </ToolbarItem>
             <ToolbarItem>
               <CheckboxField
-                changeHandler={() => setIsChecked(!isChecked)}
                 checked={isChecked}
                 label="Another form field"
+                onChange={() => setIsChecked(!isChecked)}
               />
             </ToolbarItem>
           </Toolbar>
@@ -383,14 +381,14 @@ This is a demo of all components supported by FormLayout.
           <ToolbarItem>
             <ButtonGroup>
               <Button
-                label="Vertical layout"
-                clickHandler={() => setFieldLayout('vertical')}
                 color={fieldLayout === 'vertical' ? 'dark' : 'primary'}
+                label="Vertical layout"
+                onClick={() => setFieldLayout('vertical')}
               />
               <Button
-                label="Horizontal layout"
-                clickHandler={() => setFieldLayout('horizontal')}
                 color={fieldLayout === 'horizontal' ? 'dark' : 'primary'}
+                label="Horizontal layout"
+                onClick={() => setFieldLayout('horizontal')}
               />
             </ButtonGroup>
           </ToolbarItem>
@@ -398,34 +396,28 @@ This is a demo of all components supported by FormLayout.
         <FormLayout fieldLayout={fieldLayout} labelWidth="auto">
           <>
             <TextField
-              changeHandler={() => {}}
               label="First Name"
             />
             <TextField
-              changeHandler={() => {}}
               label="Last Name"
             />
           </>
           <TextField
-            changeHandler={() => {}}
             helpText="Optional"
             label="Email address"
             type="email"
           />
           <>
             <TextField
-              changeHandler={() => {}}
               label="Address"
               placeholder="Address line 1"
             />
             <TextField
-              changeHandler={() => {}}
               isLabelVisible={false}
               label="Address 2"
               placeholder="Address line 2"
             />
             <TextField
-              changeHandler={() => {}}
               inputSize={6}
               label="ZIP"
               validationState="invalid"
@@ -435,37 +427,35 @@ This is a demo of all components supported by FormLayout.
               <span>Czech Republic</span>
             </FormLayoutCustomField>
             <CheckboxField
-              changeHandler={() => setIsDeliveryAddress(!isDeliveryAddress)}
               checked={isDeliveryAddress}
               label="This is my delivery address"
+              onChange={() => setIsDeliveryAddress(!isDeliveryAddress)}
             />
           </>
           <SelectField
-            changeHandler={(e) => setFruit(e.target.value)}
             label="Your favourite fruit"
+            onChange={(e) => setFruit(e.target.value)}
             options={options}
             value={fruit}
           />
           <TextArea
-            changeHandler={() => {}}
             fullWidth
             label="Message"
             rows={3}
           />
           <FileInputField
-            changeHandler={() => {}}
             label="Attachment"
           />
           <Toggle
-            changeHandler={() => setReceiveNewsletter(!receiveNewsletter)}
             checked={receiveNewsletter}
             helpText="Only once per week!"
             label="Receive weekly newsletter"
+            onChange={() => setReceiveNewsletter(!receiveNewsletter)}
             required
           />
           <Radio
-            changeHandler={(e) => setFruit(e.target.value)}
             label="And fruit again!"
+            onChange={(e) => setFruit(e.target.value)}
             options={options}
             value={fruit}
           />

--- a/src/lib/components/layout/Toolbar/README.mdx
+++ b/src/lib/components/layout/Toolbar/README.mdx
@@ -90,24 +90,24 @@ of `right`.
             <ToolbarItem>
               <ButtonGroup aria-labelledby="#alignment-label">
                 <Button
-                  label="top"
-                  clickHandler={() => setAlignment('top')}
                   color={alignment === 'top' ? 'dark' : 'primary'}
+                  label="top"
+                  onClick={() => setAlignment('top')}
                 />
                 <Button
-                  label="middle"
-                  clickHandler={() => setAlignment('middle')}
                   color={alignment === 'middle' ? 'dark' : 'primary'}
+                  label="middle"
+                  onClick={() => setAlignment('middle')}
                 />
                 <Button
-                  label="bottom"
-                  clickHandler={() => setAlignment('bottom')}
                   color={alignment === 'bottom' ? 'dark' : 'primary'}
+                  label="bottom"
+                  onClick={() => setAlignment('bottom')}
                 />
                 <Button
-                  label="baseline"
-                  clickHandler={() => setAlignment('baseline')}
                   color={alignment === 'baseline' ? 'dark' : 'primary'}
+                  label="baseline"
+                  onClick={() => setAlignment('baseline')}
                 />
               </ButtonGroup>
             </ToolbarItem>
@@ -119,24 +119,24 @@ of `right`.
             <ToolbarItem>
               <ButtonGroup aria-labelledby="#justification-label">
                 <Button
-                  label="start"
-                  clickHandler={() => setJustification('start')}
                   color={justification === 'start' ? 'dark' : 'primary'}
+                  label="start"
+                  onClick={() => setJustification('start')}
                 />
                 <Button
-                  label="center"
-                  clickHandler={() => setJustification('center')}
                   color={justification === 'center' ? 'dark' : 'primary'}
+                  label="center"
+                  onClick={() => setJustification('center')}
                 />
                 <Button
-                  label="end"
-                  clickHandler={() => setJustification('end')}
                   color={justification === 'end' ? 'dark' : 'primary'}
+                  label="end"
+                  onClick={() => setJustification('end')}
                 />
                 <Button
-                  label="space-between"
-                  clickHandler={() => setJustification('space-between')}
                   color={justification === 'space-between' ? 'dark' : 'primary'}
+                  label="space-between"
+                  onClick={() => setJustification('space-between')}
                 />
               </ButtonGroup>
             </ToolbarItem>
@@ -207,16 +207,16 @@ toolbar groups, or on the entire toolbar.
         <Toolbar>
           <ToolbarItem>
             <CheckboxField
-              label="Dense ToolbarGroup"
-              changeHandler={(e) => setIsGroupDense(e.target.checked)}
               checked={isGroupDense}
+              label="Dense ToolbarGroup"
+              onChange={(e) => setIsGroupDense(e.target.checked)}
             />
           </ToolbarItem>
           <ToolbarItem>
             <CheckboxField
-              label="Dense Toolbar"
-              changeHandler={(e) => setIsToolbarDense(e.target.checked)}
               checked={isToolbarDense}
+              label="Dense Toolbar"
+              onChange={(e) => setIsToolbarDense(e.target.checked)}
             />
           </ToolbarItem>
         </Toolbar>

--- a/src/lib/components/ui/Alert/Alert.jsx
+++ b/src/lib/components/ui/Alert/Alert.jsx
@@ -6,10 +6,10 @@ import styles from './Alert.scss';
 
 export const Alert = ({
   children,
-  closeHandler,
   color,
   icon,
   id,
+  onClose,
   translations,
 }) => (
   <div
@@ -31,13 +31,13 @@ export const Alert = ({
     >
       {children}
     </div>
-    {closeHandler && (
+    {onClose && (
       <button
         type="button"
         {...(id && { id: `${id}__close` })}
         className={styles.close}
-        onClick={() => closeHandler()}
-        onKeyPress={() => closeHandler()}
+        onClick={() => onClose()}
+        onKeyPress={() => onClose()}
         tabIndex="0"
         title={translations.close}
       >
@@ -48,10 +48,10 @@ export const Alert = ({
 );
 
 Alert.defaultProps = {
-  closeHandler: null,
   color: 'note',
   icon: null,
   id: undefined,
+  onClose: null,
 };
 
 Alert.propTypes = {
@@ -59,11 +59,6 @@ Alert.propTypes = {
    * Alert body.
    */
   children: PropTypes.node.isRequired,
-  /**
-   * Function to call when the close button is clicked. If not provided, close buttons will be
-   * hidden.
-   */
-  closeHandler: PropTypes.func,
   /**
    * [Color variant](/foundation/colors#component-colors) to clarify importance and meaning of the alert.
    */
@@ -82,6 +77,11 @@ Alert.propTypes = {
    * * `<ID>__content`
    */
   id: PropTypes.string,
+  /**
+   * Function to call when the close button is clicked. If not provided, close buttons will be
+   * hidden.
+   */
+  onClose: PropTypes.func,
   /**
    * Translations required by the component.
    */

--- a/src/lib/components/ui/Alert/README.mdx
+++ b/src/lib/components/ui/Alert/README.mdx
@@ -190,14 +190,14 @@ click on the close button:
           <Alert
             color="success"
             icon={<Icon icon="success" />}
-            closeHandler={() => setIsAlertVisible(false)}
+            onClose={() => setIsAlertVisible(false)}
           >
             <strong>Success:</strong> Settings have been successfully saved.
           </Alert>
         ) : (
           <Button
-            clickHandler={() => setIsAlertVisible(true)}
             label="Bring the alert back!"
+            onClick={() => setIsAlertVisible(true)}
           />
         )}
       </>

--- a/src/lib/components/ui/Alert/__tests__/Alert.test.jsx
+++ b/src/lib/components/ui/Alert/__tests__/Alert.test.jsx
@@ -28,8 +28,8 @@ describe('rendering', () => {
     ],
     [
       {
-        closeHandler: () => {},
         id: 'id',
+        onClose: () => {},
       },
       (rootElement) => {
         expect(rootElement).toHaveAttribute('id', 'id');
@@ -39,7 +39,7 @@ describe('rendering', () => {
     ],
     [
       {
-        closeHandler: () => {},
+        onClose: () => {},
         translations: { close: 'Zavřít' },
       },
       (rootElement) => expect(within(rootElement).getByTitle('Zavřít')),
@@ -57,12 +57,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls closeHandler() on Close button click', () => {
+  it('calls onClose() on Close button click', () => {
     const spy = sinon.spy();
     render((
       <Alert
         {...mandatoryProps}
-        closeHandler={spy}
+        onClose={spy}
       />
     ));
 

--- a/src/lib/components/ui/Button/Button.jsx
+++ b/src/lib/components/ui/Button/Button.jsx
@@ -15,7 +15,6 @@ export const Button = ({
   afterLabel,
   beforeLabel,
   block,
-  clickHandler,
   disabled,
   endCorner,
   feedbackIcon,
@@ -55,7 +54,6 @@ export const Button = ({
       ].join(' ')}
       disabled={resolveContextOrProp(context && context.disabled, disabled) || !!feedbackIcon}
       id={id}
-      onClick={clickHandler}
       ref={forwardedRef}
       type={type}
     >
@@ -99,7 +97,6 @@ Button.defaultProps = {
   afterLabel: null,
   beforeLabel: null,
   block: false,
-  clickHandler: null,
   color: 'primary',
   disabled: false,
   endCorner: null,
@@ -129,10 +126,6 @@ Button.propTypes = {
    * as the value is inherited in such case.
    */
   block: PropTypes.bool,
-  /**
-   * Function to call when the button is clicked.
-   */
-  clickHandler: PropTypes.func,
   /**
    * [Color variant](/foundation/colors#component-colors) to clarify importance and meaning of the button.
    */

--- a/src/lib/components/ui/Button/README.mdx
+++ b/src/lib/components/ui/Button/README.mdx
@@ -397,9 +397,10 @@ animation is made.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `button` HTML element.
-This is useful mainly to improve component's accessibility.
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `button` HTML element. This enables making the component
+interactive and helps improve its accessibility.
 
 <Props table of={Button} />
 
@@ -552,3 +553,5 @@ feedback state.
 |-----------------------------------|------------------------------------------------------|
 | `--rui-Button--feedback__opacity` | Opacity of buttons in feedback state                 |
 | `--rui-Button--feedback__cursor`  | Cursor to show on hovering buttons in feedback state |
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/Button/__tests__/Button.test.jsx
+++ b/src/lib/components/ui/Button/__tests__/Button.test.jsx
@@ -175,12 +175,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls clickHandler()', () => {
+  it('calls synthetic event onClick()', () => {
     const spy = sinon.spy();
     render((
       <Button
         {...mandatoryProps}
-        clickHandler={spy}
+        onClick={spy}
       />
     ));
 

--- a/src/lib/components/ui/CheckboxField/CheckboxField.jsx
+++ b/src/lib/components/ui/CheckboxField/CheckboxField.jsx
@@ -8,7 +8,6 @@ import withForwardedRef from '../withForwardedRef';
 import styles from './CheckboxField.scss';
 
 export const CheckboxField = ({
-  changeHandler,
   checked,
   disabled,
   forwardedRef,
@@ -46,7 +45,6 @@ export const CheckboxField = ({
           className={styles.input}
           disabled={disabled}
           id={id}
-          onChange={changeHandler}
           ref={forwardedRef}
           required={required}
           type="checkbox"
@@ -83,7 +81,6 @@ export const CheckboxField = ({
 };
 
 CheckboxField.defaultProps = {
-  changeHandler: null,
   checked: undefined,
   disabled: false,
   forwardedRef: undefined,
@@ -98,10 +95,6 @@ CheckboxField.defaultProps = {
 };
 
 CheckboxField.propTypes = {
-  /**
-   * Function to call when the input is toggled.
-   */
-  changeHandler: PropTypes.func,
   /**
    * If `true`, the input will be checked.
    */

--- a/src/lib/components/ui/CheckboxField/README.mdx
+++ b/src/lib/components/ui/CheckboxField/README.mdx
@@ -29,9 +29,9 @@ And use it:
     const [agree, setAgree] = React.useState(true);
     return (
       <CheckboxField
-        changeHandler={() => setAgree(!agree)}
         checked={agree}
         label="I agree"
+        onChange={() => setAgree(!agree)}
       />
     );
   }}
@@ -81,10 +81,10 @@ turning the checkbox on or off.
     const [getNewsletter, setGetNewsletter] = React.useState(true);
     return (
       <CheckboxField
-        changeHandler={() => setGetNewsletter(!getNewsletter)}
         checked={getNewsletter}
         helpText="We will not bother you more than once a month, we promise!"
         label="Send me newsletter"
+        onChange={() => setGetNewsletter(!getNewsletter)}
       />
     );
   }}
@@ -100,10 +100,10 @@ label remains accessible to assistive technologies.
     const [checked, setChecked] = React.useState(true);
     return (
       <CheckboxField
-        changeHandler={() => setChecked(!checked)}
         checked={checked}
         isLabelVisible={false}
         label="You cannot see this"
+        onChange={() => setChecked(!checked)}
       />
     );
   }}
@@ -116,10 +116,10 @@ It's also possible to display label before input:
     const [checked, setChecked] = React.useState(true);
     return (
       <CheckboxField
-        changeHandler={() => setChecked(!checked)}
         checked={checked}
         label="Label precedes input"
         labelPosition="before"
+        onChange={() => setChecked(!checked)}
       />
     );
   }}
@@ -140,22 +140,22 @@ have.
     return (
       <>
         <CheckboxField
-          changeHandler={() => setAgree(!agree)}
           checked={agree}
           label="I have read and agree with terms and conditions"
+          onChange={() => setAgree(!agree)}
           validationState="valid"
         />
         <CheckboxField
-          changeHandler={() => setAgree(!agree)}
           checked={agree}
           label="I have read and agree with terms and conditions"
+          onChange={() => setAgree(!agree)}
           validationState="warning"
           validationText="Please wait 10 minutes until we verify your data."
         />
         <CheckboxField
-          changeHandler={() => setAgree(!agree)}
           checked={agree}
           label="I have read and agree with terms and conditions"
+          onChange={() => setAgree(!agree)}
           required
           validationState="invalid"
           validationText="You must agree to be able to proceed."
@@ -183,9 +183,10 @@ Disabled state makes the input unavailable.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `input` HTML element.
-This is useful mainly to improve component's accessibility.
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `input` HTML element. This enables making the component
+interactive and helps improve its accessibility.
 
 <Props table of={CheckboxField} />
 
@@ -198,3 +199,5 @@ options. On top of that, the following options are available for CheckboxField.
 |----------------------------------------------------------------------|----------------------------------------------|
 | `--rui-FormField--check__input--checkbox__border-radius`             | Input corner radius                          |
 | `--rui-FormField--check__input--checkbox--checked__background-image` | Background image of checked input            |
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/CheckboxField/__tests__/CheckboxField.test.jsx
+++ b/src/lib/components/ui/CheckboxField/__tests__/CheckboxField.test.jsx
@@ -27,15 +27,15 @@ describe('rendering', () => {
   it.each([
     [
       {
-        changeHandler: () => {},
         checked: true,
+        onChange: () => {},
       },
       (rootElement) => expect(within(rootElement).getByRole('checkbox')).toBeChecked(),
     ],
     [
       {
-        changeHandler: () => {},
         checked: false,
+        onChange: () => {},
       },
       (rootElement) => expect(within(rootElement).getByRole('checkbox')).not.toBeChecked(),
     ],
@@ -82,12 +82,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls clickHandler()', () => {
+  it('calls synthetic event onChange()', () => {
     const spy = sinon.spy();
     render((
       <CheckboxField
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
       />
     ));
 

--- a/src/lib/components/ui/FileInputField/FileInputField.jsx
+++ b/src/lib/components/ui/FileInputField/FileInputField.jsx
@@ -9,7 +9,6 @@ import withForwardedRef from '../withForwardedRef';
 import styles from './FileInputField.scss';
 
 export const FileInputField = ({
-  changeHandler,
   disabled,
   forwardedRef,
   fullWidth,
@@ -57,7 +56,6 @@ export const FileInputField = ({
             className={styles.input}
             disabled={disabled}
             id={id}
-            onChange={changeHandler}
             ref={forwardedRef}
             required={required}
             type="file"
@@ -85,7 +83,6 @@ export const FileInputField = ({
 };
 
 FileInputField.defaultProps = {
-  changeHandler: null,
   disabled: false,
   forwardedRef: undefined,
   fullWidth: false,
@@ -99,10 +96,6 @@ FileInputField.defaultProps = {
 };
 
 FileInputField.propTypes = {
-  /**
-   * Function to call when the input has changed.
-   */
-  changeHandler: PropTypes.func,
   /**
    * If `true`, the input will be disabled.
    */

--- a/src/lib/components/ui/FileInputField/README.mdx
+++ b/src/lib/components/ui/FileInputField/README.mdx
@@ -189,10 +189,10 @@ It's possible to disable the whole input.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `input` HTML element.
-This is useful mainly to improve component's
-[accessibility](#forwarding-html-attributes).
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `input` HTML element. This enables making the component
+interactive and helps improve its [accessibility](#forwarding-html-attributes).
 
 <Props table of={FileInputField} />
 
@@ -200,3 +200,5 @@ This is useful mainly to improve component's
 
 Head to [Forms Theming](/customize/theming/forms) to see shared form theming
 options.
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/FileInputField/__tests__/FileInputField.test.jsx
+++ b/src/lib/components/ui/FileInputField/__tests__/FileInputField.test.jsx
@@ -64,12 +64,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls clickHandler()', () => {
+  it('calls synthetic event onChange()', () => {
     const spy = sinon.spy();
     render((
       <FileInputField
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
       />
     ));
 

--- a/src/lib/components/ui/Link/Link.jsx
+++ b/src/lib/components/ui/Link/Link.jsx
@@ -6,7 +6,6 @@ import styles from './Link.scss';
 
 export const Link = ({
   children,
-  clickHandler,
   href,
   id,
   ...restProps
@@ -16,7 +15,6 @@ export const Link = ({
     href={href}
     className={styles.root}
     id={id}
-    onClick={clickHandler}
   >
     {children}
   </a>
@@ -24,7 +22,6 @@ export const Link = ({
 
 Link.defaultProps = {
   children: null,
-  clickHandler: undefined,
   id: undefined,
 };
 
@@ -33,10 +30,6 @@ Link.propTypes = {
    * Content of the link.
    */
   children: PropTypes.node,
-  /**
-   * Function to call when the link is clicked.
-   */
-  clickHandler: PropTypes.func,
   /**
    * Link's `href` attribute.
    */

--- a/src/lib/components/ui/Link/README.mdx
+++ b/src/lib/components/ui/Link/README.mdx
@@ -50,12 +50,12 @@ Besides text, link can contain block-level elements too.
 ## Custom Routing
 
 It's common to use custom function for routing within SPAs. Use the
-`clickHandler` option to provide such function.
+`onClick` option to provide such function.
 
 <Playground>
   <Link
     href="/contribute/guidelines"
-    clickHandler={(event) => {
+    onClick={(event) => {
       event.preventDefault();
       window.location = event.currentTarget.getAttribute('href');
     }}
@@ -66,9 +66,10 @@ It's common to use custom function for routing within SPAs. Use the
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `a` HTML element.
-This is useful mainly to improve component's accessibility.
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `a` HTML element. This enables making the component interactive
+and helps improve its accessibility.
 
 <Props table of={Link} />
 
@@ -80,3 +81,5 @@ This is useful mainly to improve component's accessibility.
 | `--rui-Link__text-decoration`        | Text decoration, e.g. underline              |
 | `--rui-Link--hover__color`           | Text color on hover                          |
 | `--rui-Link--hover__text-decoration` | Text decoration on hover                     |
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/Link/__tests__/Link.test.jsx
+++ b/src/lib/components/ui/Link/__tests__/Link.test.jsx
@@ -38,12 +38,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls clickHandler()', () => {
+  it('calls synthetic event onClick()', () => {
     const spy = sinon.spy();
     render((
       <Link
         {...mandatoryProps}
-        clickHandler={spy}
+        onClick={spy}
       >
         link text
       </Link>

--- a/src/lib/components/ui/Modal/Modal.jsx
+++ b/src/lib/components/ui/Modal/Modal.jsx
@@ -54,18 +54,18 @@ export class Modal extends React.Component {
   keyPressHandler(e) {
     const {
       actions,
-      closeHandler,
+      onClose,
     } = this.props;
 
-    if (e.keyCode === 27 && closeHandler) {
-      closeHandler();
+    if (e.keyCode === 27 && onClose) {
+      onClose();
     }
 
     if (e.keyCode === 13 && e.target.nodeName !== 'BUTTON') {
       const submitAction = actions.find((action) => action.type === 'submit');
 
       if (submitAction && !submitAction.disabled) {
-        submitAction.clickHandler(e);
+        submitAction.onClick(e);
       }
     }
   }
@@ -74,8 +74,8 @@ export class Modal extends React.Component {
     const {
       actions,
       children,
-      closeHandler,
       id,
+      onClose,
       position,
       scrollView,
       size,
@@ -147,8 +147,8 @@ export class Modal extends React.Component {
         className={styles.backdrop}
         id={id}
         onClick={(e) => {
-          if (closeHandler) {
-            closeHandler(e);
+          if (onClose) {
+            onClose(e);
           }
         }}
         role="presentation"
@@ -171,11 +171,11 @@ export class Modal extends React.Component {
             >
               {title}
             </h3>
-            {closeHandler && (
+            {onClose && (
               <button
                 type="button"
                 className={styles.close}
-                onClick={closeHandler}
+                onClick={onClose}
                 title={translations.close}
                 {...(id && { id: `${id}__closeModalHeaderButton` })}
               >
@@ -184,29 +184,29 @@ export class Modal extends React.Component {
             )}
           </div>
           {modalBody()}
-          {(actions.length || closeHandler) && (
+          {(actions.length || onClose) && (
             <div className={styles.footer}>
               <Toolbar justify="center" dense>
                 {actions.map((action) => (
                   <ToolbarItem key={action.label}>
                     <Button
                       {...transferProps(action)}
-                      clickHandler={action.clickHandler}
                       color={action.color}
                       disabled={action.disabled}
                       feedbackIcon={action.feedbackIcon}
+                      forwardedRef={this.submitButtonRef}
                       id={action.id || undefined}
                       label={action.label}
-                      forwardedRef={this.submitButtonRef}
+                      onClick={action.onClick}
                       type="button"
                     />
                   </ToolbarItem>
                 ))}
-                {closeHandler && (
+                {onClose && (
                   <ToolbarItem>
                     <Button
-                      clickHandler={closeHandler}
                       label={translations.close}
+                      onClick={onClose}
                       priority="flat"
                       {...(id && { id: `${id}__closeModalFooterButton` })}
                     />
@@ -234,8 +234,8 @@ export class Modal extends React.Component {
 Modal.defaultProps = {
   actions: [],
   autoFocus: true,
-  closeHandler: null,
   id: undefined,
+  onClose: null,
   portalId: null,
   position: 'center',
   scrollView: (<ScrollView
@@ -251,12 +251,12 @@ Modal.propTypes = {
    * Actions to be rendered in modal footer.
    */
   actions: PropTypes.arrayOf(PropTypes.shape({
-    clickHandler: PropTypes.func.isRequired,
     color: PropTypes.oneOf(['primary', 'secondary', 'success', 'warning', 'danger', 'help', 'info', 'note', 'light', 'dark']),
     disabled: PropTypes.bool,
     feedbackIcon: PropTypes.node,
     id: PropTypes.string,
     label: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
   })),
   /**
    * If `true`, focus the first action in the footer when the modal is opened.
@@ -267,16 +267,16 @@ Modal.propTypes = {
    */
   children: PropTypes.node.isRequired,
   /**
-   * If a function is provided, the close buttons will be displayed.
-   */
-  closeHandler: PropTypes.func,
-  /**
    * ID of the root HTML element. It also serves as a base for nested elements:
    * * `<ID>__content`
    * * `<ID>__closeModalHeaderButton`
    * * `<ID>__closeModalFooterButton`
    */
   id: PropTypes.string,
+  /**
+   * If a function is provided, the close buttons will be displayed.
+   */
+  onClose: PropTypes.func,
   /**
    * If set, the modal is rendered in the React Portal with that ID.
    */

--- a/src/lib/components/ui/Modal/README.mdx
+++ b/src/lib/components/ui/Modal/README.mdx
@@ -34,20 +34,20 @@ And use it:
     return (
       <>
         <Button
-          clickHandler={() => setModalOpen(true)}
           label="Launch modal"
+          onClick={() => setModalOpen(true)}
           priority="outline"
         />
         <div>
           {modalOpen && (
             <Modal
-              title="Warning"
               actions={[{
-                clickHandler: () => setModalOpen(false),
-                label: 'Delete',
                 color: 'danger',
+                label: 'Delete',
+                onClick: () => setModalOpen(false),
               }]}
-              closeHandler={() => setModalOpen(false)}
+              onClose={() => setModalOpen(false)}
+              title="Warning"
             >
               <p>
                 Do you really want to delete the user <code>admin</code>?
@@ -96,48 +96,48 @@ Modals of any size automatically shrink when they cannot fit the screen width.
     return (
       <>
         <Button
-          clickHandler={() => {
+          label="Launch small modal"
+          onClick={() => {
             setModalSize('small');
             setModalOpen(true);
           }}
-          label="Launch small modal"
           priority="outline"
         />
         <Button
-          clickHandler={() => {
+          label="Launch medium modal"
+          onClick={() => {
             setModalSize('medium');
             setModalOpen(true);
           }}
-          label="Launch medium modal"
           priority="outline"
         />
         <Button
-          clickHandler={() => {
+          label="Launch large modal"
+          onClick={() => {
             setModalSize('large');
             setModalOpen(true);
           }}
-          label="Launch large modal"
           priority="outline"
         />
         <Button
-          clickHandler={() => {
+          label="Launch fullscreen modal"
+          onClick={() => {
             setModalSize('fullscreen');
             setModalOpen(true);
           }}
-          label="Launch fullscreen modal"
           priority="outline"
         />
         <div>
           {modalOpen && (
             <Modal
-              title="Delete the user?"
               actions={[{
-                clickHandler: () => setModalOpen(false),
-                label: 'Delete',
                 color: 'danger',
+                label: 'Delete',
+                onClick: () => setModalOpen(false),
               }]}
-              closeHandler={() => setModalOpen(false)}
+              onClose={() => setModalOpen(false)}
               size={modalSize}
+              title="Delete the user?"
             >
               <p>
                 Do you really want to delete the user <code>admin</code>?
@@ -164,21 +164,21 @@ magic that doesn't work together yet 🎩.
     return (
       <>
         <Button
-          clickHandler={() => setModalOpen(true)}
           label="Launch auto-width modal"
+          onClick={() => setModalOpen(true)}
           priority="outline"
         />
         <div>
           {modalOpen && (
             <Modal
-              title="Delete the user?"
               actions={[{
-                clickHandler: () => setModalOpen(false),
-                label: 'Delete',
                 color: 'danger',
+                label: 'Delete',
+                onClick: () => setModalOpen(false),
               }]}
-              closeHandler={() => setModalOpen(false)}
+              onClose={() => setModalOpen(false)}
               size="auto"
+              title="Delete the user?"
             >
               <p>
                 Do you really want to delete the user <code>admin</code>?
@@ -203,32 +203,32 @@ Modal can be aligned either to top or center of the screen.
     return (
       <>
         <Button
-          clickHandler={() => {
+          label="Launch modal at center"
+          onClick={() => {
             setModalPosition('center');
             setModalOpen(true);
           }}
-          label="Launch modal at center"
           priority="outline"
         />
         <Button
-          clickHandler={() => {
+          label="Launch modal at top"
+          onClick={() => {
             setModalPosition('top');
             setModalOpen(true);
           }}
-          label="Launch modal at top"
           priority="outline"
         />
         <div>
           {modalOpen && (
             <Modal
-              title="Delete the user?"
               actions={[{
-                clickHandler: () => setModalOpen(false),
+                onClick: () => setModalOpen(false),
                 label: 'Delete',
                 color: 'danger',
               }]}
-              closeHandler={() => setModalOpen(false)}
+              onClose={() => setModalOpen(false)}
               position={modalPosition}
+              title="Delete the user?"
             >
               <p>
                 Do you really want to delete the user <code>admin</code>?
@@ -258,33 +258,33 @@ component.
     return (
       <>
         <Button
-          clickHandler={() => {
+          label="Launch modal with scrolling body"
+          onClick={() => {
             setModalScrollView(true);
             setModalOpen(true);
           }}
-          label="Launch modal with scrolling body"
           priority="outline"
         />
         <Button
-          clickHandler={() => {
+          label="Launch scrolling modal"
+          onClick={() => {
             setModalScrollView(false);
             setModalOpen(true);
           }}
-          label="Launch scrolling modal"
           priority="outline"
         />
         <div>
           {modalOpen && (
             <Modal
-              title="Modal with long content"
               actions={[{
-                clickHandler: () => setModalOpen(false),
                 label: 'OK',
+                onClick: () => setModalOpen(false),
               }]}
               autoFocus={false}
-              closeHandler={() => setModalOpen(false)}
+              onClose={() => setModalOpen(false)}
               scrollView={modalScrollView ? undefined : null}
               size="small"
+              title="Modal with long content"
             >
               <p>
                 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
@@ -380,8 +380,8 @@ to prevent interaction. That's where blocking modals may come handy.
     return (
       <>
         <Button
-          clickHandler={() => setModalOpen(true)}
           label="Launch blocking modal"
+          onClick={() => setModalOpen(true)}
           priority="outline"
         />
         <div>
@@ -393,8 +393,8 @@ to prevent interaction. That's where blocking modals may come handy.
                 Don&apos;t turn off the device!
               </p>
               <Button
-                clickHandler={() => setModalOpen(false)}
                 label="Close the demo"
+                onClick={() => setModalOpen(false)}
                 priority="flat"
               />
             </Modal>

--- a/src/lib/components/ui/Modal/__tests__/Modal.test.jsx
+++ b/src/lib/components/ui/Modal/__tests__/Modal.test.jsx
@@ -40,8 +40,8 @@ describe('rendering', () => {
     ],
     [
       {
-        closeHandler: () => {},
         id: 'id',
+        onClose: () => {},
       },
       (rootElement) => {
         expect(rootElement).toHaveAttribute('id', 'id');
@@ -85,7 +85,7 @@ describe('rendering', () => {
     ],
     [
       {
-        closeHandler: () => {},
+        onClose: () => {},
         translations: { close: 'Zavřít' },
       },
       (rootElement) => expect(within(rootElement).getByTitle('Zavřít')),
@@ -107,12 +107,12 @@ describe('functionality', () => {
     () => userEvent.click(screen.getByText('Close')),
     () => userEvent.keyboard('{esc}'),
     () => userEvent.click(screen.getByTestId('id')),
-  ])('call closeHandler() (%#)', (action) => {
+  ])('call onClose() (%#)', (action) => {
     const spy = sinon.spy();
     render((
       <Modal
         {...mandatoryProps}
-        closeHandler={spy}
+        onClose={spy}
         id="id"
       >
         Modal content
@@ -133,13 +133,13 @@ describe('functionality', () => {
         {...mandatoryProps}
         actions={[
           {
-            clickHandler: spy,
             label: 'submit',
+            onClick: spy,
             type: 'submit',
           },
           {
-            clickHandler: spy,
             label: 'action',
+            onClick: spy,
             type: 'button',
           },
         ]}
@@ -162,9 +162,9 @@ describe('functionality', () => {
         {...mandatoryProps}
         actions={[
           {
-            clickHandler: spy,
             disabled: true,
             label: 'submit',
+            onClick: spy,
             type: 'submit',
           },
         ]}

--- a/src/lib/components/ui/Radio/README.mdx
+++ b/src/lib/components/ui/Radio/README.mdx
@@ -29,8 +29,8 @@ And use it:
     const [fruit, setFruit] = React.useState('apple');
     return (
       <Radio
-        changeHandler={(e) => setFruit(e.target.value)}
         label="Your favourite fruit"
+        onChange={(e) => setFruit(e.target.value)}
         options={[
           {
             label: 'Apple',
@@ -91,9 +91,9 @@ the input.
     const [frequency, setFrequency] = React.useState('weekly');
     return (
       <Radio
-        changeHandler={(e) => setFrequency(e.target.value)}
         isLabelVisible={false}
         label="Newsletter frequency"
+        onChange={(e) => setFrequency(e.target.value)}
         options={[
           {
             label: 'I want to subscribe to the weekly newsletter',
@@ -125,9 +125,9 @@ supports this kind of layout as well.
     const [frequency, setFrequency] = React.useState('weekly');
     return (
       <Radio
-        changeHandler={(e) => setFrequency(e.target.value)}
         label="Newsletter frequency"
         layout="horizontal"
+        onChange={(e) => setFrequency(e.target.value)}
         options={[
           {
             label: 'I want to subscribe to the weekly newsletter',
@@ -158,9 +158,9 @@ filled.
     const [fruit, setFruit] = React.useState('apple');
     return (
       <Radio
-        changeHandler={(e) => setFruit(e.target.value)}
         helpText="What do you prefer?"
         label="Your favourite fruit"
+        onChange={(e) => setFruit(e.target.value)}
         options={[
           {
             label: 'Apple',
@@ -210,8 +210,8 @@ have.
     return (
       <>
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="valid"
@@ -219,8 +219,8 @@ have.
           value={fruit}
         />
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="warning"
@@ -228,8 +228,8 @@ have.
           value={fruit}
         />
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="invalid"
@@ -266,15 +266,15 @@ It's possible to disable just some options or the whole set.
     return (
       <>
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <Radio
-          changeHandler={(e) => setFruit(e.target.value)}
           disabled
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value="apple"
         />
@@ -285,9 +285,10 @@ It's possible to disable just some options or the whole set.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `input` HTML element.
-This is useful mainly to improve component's accessibility.
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `input` HTML element. This enables making the component
+interactive and helps improve its accessibility.
 
 <Props table of={Radio} />
 
@@ -300,3 +301,5 @@ options. On top of that, the following options are available for Radio.
 |--------------------------------------------------------------------|------------------------------------------------|
 | `--rui-FormField--check__input--radio__border-radius`              | Input corner radius                            |
 | `--rui-FormField--check__input--radio--checked__background-image` | Checked input background image (inline, URL, …) |
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/Radio/Radio.jsx
+++ b/src/lib/components/ui/Radio/Radio.jsx
@@ -8,7 +8,6 @@ import { FormLayoutContext } from '../../layout/FormLayout';
 import styles from './Radio.scss';
 
 export const Radio = ({
-  changeHandler,
   disabled,
   helpText,
   id,
@@ -60,13 +59,12 @@ export const Radio = ({
                   <input
                     {...transferProps(restProps)}
                     className={styles.input}
-                    checked={changeHandler
+                    checked={restProps.onChange
                       ? (value === option.value) || false
                       : undefined}
                     disabled={disabled || option.disabled}
                     id={id && `${id}__item__${option.value}`}
                     name={id}
-                    onChange={changeHandler}
                     type="radio"
                     value={option.value}
                   />
@@ -103,7 +101,6 @@ export const Radio = ({
 };
 
 Radio.defaultProps = {
-  changeHandler: null,
   disabled: false,
   helpText: null,
   id: undefined,
@@ -116,10 +113,6 @@ Radio.defaultProps = {
 };
 
 Radio.propTypes = {
-  /**
-   * Function to call when the input has changed.
-   */
-  changeHandler: PropTypes.func,
   /**
    * If `true`, the input will be disabled.
    */

--- a/src/lib/components/ui/Radio/__tests__/Radio.test.jsx
+++ b/src/lib/components/ui/Radio/__tests__/Radio.test.jsx
@@ -82,14 +82,14 @@ describe('rendering', () => {
     ...validationTextPropTest,
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 'option2',
       },
       (rootElement) => expect(within(rootElement).getByLabelText('option 2')).toHaveAttribute('checked'),
     ],
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 1,
       },
       (rootElement) => expect(within(rootElement).getByLabelText('option 1')).toHaveAttribute('checked'),
@@ -107,12 +107,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls clickHandler()', () => {
+  it('calls synthetic event onChange()', () => {
     const spy = sinon.spy();
     render((
       <Radio
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
       />
     ));
 

--- a/src/lib/components/ui/ScrollView/README.mdx
+++ b/src/lib/components/ui/ScrollView/README.mdx
@@ -219,7 +219,8 @@ property defined because it detects changes of these keys.
         <Toolbar>
           <ToolbarItem>
             <Radio
-              changeHandler={(e) => setDirection(e.target.value)}
+              label="Direction:"
+              onChange={(e) => setDirection(e.target.value)}
               options={[
                 {
                   label: 'Vertical',
@@ -230,13 +231,13 @@ property defined because it detects changes of these keys.
                   value: 'horizontal',
                 },
               ]}
-              label="Direction:"
               value={direction}
             />
           </ToolbarItem>
           <ToolbarItem>
             <Radio
-              changeHandler={(e) => setAutoScroll(e.target.value)}
+              label="Autoscroll:"
+              onChange={(e) => setAutoScroll(e.target.value)}
               options={[
                 {
                   label: 'Always',
@@ -247,14 +248,13 @@ property defined because it detects changes of these keys.
                   value: 'detectEnd',
                 },
               ]}
-              label="Autoscroll:"
               value={autoScroll}
             />
           </ToolbarItem>
           <ToolbarItem>
             <Button
               label="Add text"
-              clickHandler={
+              onClick={
                 () => setScrollViewContent(
                   `${scrollViewContent} ${generateRandomString()}`,
                 )

--- a/src/lib/components/ui/SelectField/README.mdx
+++ b/src/lib/components/ui/SelectField/README.mdx
@@ -29,8 +29,8 @@ And use it:
     const [fruit, setFruit] = React.useState('apple');
     return (
       <SelectField
-        changeHandler={(e) => setFruit(e.target.value)}
         label="Your favourite fruit"
+        onChange={(e) => setFruit(e.target.value)}
         options={[
           {
             label: 'Apple',
@@ -110,14 +110,14 @@ further [customized](#theming) with CSS custom properties.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           variant="filled"
           value={fruit}
@@ -152,43 +152,43 @@ and large.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           size="small"
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           size="large"
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           size="small"
           value={fruit}
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           size="large"
           value={fruit}
@@ -221,16 +221,16 @@ Full-width fields span the full width of a parent:
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           fullWidth
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           fullWidth
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
@@ -267,16 +267,16 @@ the input.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           isLabelVisible={false}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           isLabelVisible={false}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
@@ -312,52 +312,52 @@ supports this kind of layout as well.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
           layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
           layout="horizontal"
-          options={options}
-          value={fruit}
-          variant="filled"
-        />
-        <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
-          fullWidth
-          label="Your favourite fruit"
-          layout="horizontal"
-          options={options}
-          value={fruit}
-        />
-        <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
-          fullWidth
-          label="Your favourite fruit"
-          layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           fullWidth
-          isLabelVisible={false}
           label="Your favourite fruit"
           layout="horizontal"
-          value={fruit}
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
+          value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
+          fullWidth
+          label="Your favourite fruit"
+          layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+          variant="filled"
+        />
+        <SelectField
           fullWidth
           isLabelVisible={false}
           label="Your favourite fruit"
           layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+        />
+        <SelectField
+          fullWidth
+          isLabelVisible={false}
+          label="Your favourite fruit"
+          layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
@@ -392,52 +392,52 @@ filled.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           helpText="Choose one or more kinds of fruit to feel happy."
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           helpText="Choose one or more kinds of fruit to feel happy."
           label="Your favourite fruit"
-          options={options}
-          value={fruit}
-          variant="filled"
-        />
-        <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
-          helpText="Choose one or more kinds of fruit to feel happy."
-          label="Your favourite fruit"
-          layout="horizontal"
-          options={options}
-          value={fruit}
-        />
-        <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
-          helpText="Choose one or more kinds of fruit to feel happy."
-          label="Your favourite fruit"
-          layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
-          fullWidth
           helpText="Choose one or more kinds of fruit to feel happy."
           label="Your favourite fruit"
           layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
+          helpText="Choose one or more kinds of fruit to feel happy."
+          label="Your favourite fruit"
+          layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+          variant="filled"
+        />
+        <SelectField
           fullWidth
           helpText="Choose one or more kinds of fruit to feel happy."
           label="Your favourite fruit"
           layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+        />
+        <SelectField
+          fullWidth
+          helpText="Choose one or more kinds of fruit to feel happy."
+          label="Your favourite fruit"
+          layout="horizontal"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
@@ -476,8 +476,8 @@ have.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="valid"
@@ -485,8 +485,8 @@ have.
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="warning"
@@ -494,8 +494,8 @@ have.
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="invalid"
@@ -503,8 +503,8 @@ have.
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="valid"
@@ -513,8 +513,8 @@ have.
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           validationState="warning"
@@ -523,8 +523,8 @@ have.
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           required
           value={fruit}
@@ -562,29 +562,29 @@ It's possible to disable just some options or the whole input.
     return (
       <>
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value={fruit}
           variant="filled"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           disabled
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value="apple"
         />
         <SelectField
-          changeHandler={(e) => setFruit(e.target.value)}
           disabled
           label="Your favourite fruit"
+          onChange={(e) => setFruit(e.target.value)}
           options={options}
           value="apple"
           variant="filled"
@@ -596,9 +596,10 @@ It's possible to disable just some options or the whole input.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `select` HTML element.
-This is useful mainly to improve component's accessibility.
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `select` HTML element. This enables making the component
+interactive and helps improve its accessibility.
 
 <Props table of={SelectField} />
 
@@ -612,3 +613,5 @@ options. On top of that, the following options are available for SelectField.
 | `--rui-FormField--box--select__caret__border-style`  | SelectField arrow border style (e.g. `solid`)                |
 | `--rui-FormField--box--select__caret__background`    | SelectField arrow background (including `url()` or gradient) |
 | `--rui-FormField--box--select__option--disabled__color` | Text color of disabled SelectField options                |
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/SelectField/SelectField.jsx
+++ b/src/lib/components/ui/SelectField/SelectField.jsx
@@ -10,7 +10,6 @@ import withForwardedRef from '../withForwardedRef';
 import styles from './SelectField.scss';
 
 export const SelectField = ({
-  changeHandler,
   disabled,
   forwardedRef,
   fullWidth,
@@ -64,7 +63,6 @@ export const SelectField = ({
             className={styles.input}
             disabled={disabled}
             id={id}
-            onChange={changeHandler}
             ref={forwardedRef}
             required={required}
             value={value}
@@ -111,7 +109,6 @@ export const SelectField = ({
 };
 
 SelectField.defaultProps = {
-  changeHandler: null,
   disabled: false,
   forwardedRef: undefined,
   fullWidth: false,
@@ -128,10 +125,6 @@ SelectField.defaultProps = {
 };
 
 SelectField.propTypes = {
-  /**
-   * Function to call when the input has changed.
-   */
-  changeHandler: PropTypes.func,
   /**
    * If `true`, the input will be disabled.
    */

--- a/src/lib/components/ui/SelectField/__tests__/SelectField.test.jsx
+++ b/src/lib/components/ui/SelectField/__tests__/SelectField.test.jsx
@@ -76,14 +76,14 @@ describe('rendering', () => {
     ...validationTextPropTest,
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 'option2',
       },
       (rootElement) => expect(within(rootElement).getByDisplayValue('option 2')),
     ],
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 1,
       },
       (rootElement) => expect(within(rootElement).getByDisplayValue('option 1')),
@@ -102,12 +102,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls changeHandler() on changing selected option', () => {
+  it('calls synthetic event onChange() on changing selected option', () => {
     const spy = sinon.spy();
     render((
       <SelectField
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
         value="option2"
       />
     ));

--- a/src/lib/components/ui/Table/README.mdx
+++ b/src/lib/components/ui/Table/README.mdx
@@ -240,14 +240,14 @@ The following is an example of custom sorting function executed on the client.
         rows={rows}
         sort={{
           ascendingIcon: <Icon icon="up" />,
-          changeHandler: (column, direction) => {
+          column: tableSortColumn,
+          descendingIcon: <Icon icon="down" />,
+          direction: tableSortDirection,
+          onClick: (column, direction) => {
             setTableSortColumn(column);
             setTableSortDirection(direction === 'asc' ? 'desc' : 'asc');
             setRows(compare(rows, column, direction));
           },
-          column: tableSortColumn,
-          descendingIcon: <Icon icon="down" />,
-          direction: tableSortDirection,
         }}
       />
     );

--- a/src/lib/components/ui/Table/Table.jsx
+++ b/src/lib/components/ui/Table/Table.jsx
@@ -32,7 +32,6 @@ export class Table extends React.Component {
         {sort && column.isSortable && (
           <div className={styles.sortButton}>
             <Button
-              clickHandler={() => sort.changeHandler(column.name, sortDirection)}
               beforeLabel={
                 sortDirection === 'asc'
                   ? sort.ascendingIcon
@@ -40,6 +39,7 @@ export class Table extends React.Component {
               }
               label={sortDirection}
               labelVisibility="none"
+              onClick={() => sort.onClick(column.name, sortDirection)}
               priority="flat"
               {...(id && { id: `${id}__headerCell__${column.name}__sortButton` })}
             />
@@ -138,10 +138,10 @@ Table.propTypes = {
    */
   sort: PropTypes.shape({
     ascendingIcon: PropTypes.node.isRequired,
-    changeHandler: PropTypes.func.isRequired,
     column: PropTypes.string.isRequired,
     descendingIcon: PropTypes.node.isRequired,
     direction: PropTypes.oneOf(['asc', 'desc']).isRequired,
+    onClick: PropTypes.func.isRequired,
   }),
 };
 

--- a/src/lib/components/ui/Table/__tests__/Table.test.jsx
+++ b/src/lib/components/ui/Table/__tests__/Table.test.jsx
@@ -47,10 +47,10 @@ describe('rendering', () => {
         id: 'id',
         sort: {
           ascendingIcon: <span>ascending icon</span>,
-          changeHandler: () => {},
           column: 'name',
           descendingIcon: <span>descending icon</span>,
           direction: 'asc',
+          onClick: () => {},
         },
       },
       (rootElement) => {
@@ -78,10 +78,10 @@ describe('rendering', () => {
       {
         sort: {
           ascendingIcon: <span>ascending icon</span>,
-          changeHandler: () => {},
           column: 'dateOfBirth',
           descendingIcon: <span>descending icon</span>,
           direction: 'asc',
+          onClick: () => {},
         },
       },
       (rootElement) => expect(within(rootElement).getByText('ascending icon')),
@@ -90,10 +90,10 @@ describe('rendering', () => {
       {
         sort: {
           ascendingIcon: <span>ascending icon</span>,
-          changeHandler: () => {},
           column: 'dateOfBirth',
           descendingIcon: <span>descending icon</span>,
           direction: 'desc',
+          onClick: () => {},
         },
       },
       (rootElement) => expect(within(rootElement).getByText('descending icon')),
@@ -111,17 +111,17 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls changeHandler() on sorting button click', () => {
+  it('calls onClick() on sorting button click', () => {
     const spy = sinon.spy();
     render((
       <Table
         {...mandatoryProps}
         sort={{
           ascendingIcon: <span>ascending icon</span>,
-          changeHandler: spy,
           column: 'dateOfBirth',
           descendingIcon: <span>descending icon</span>,
           direction: 'asc',
+          onClick: spy,
         }}
       />
     ));

--- a/src/lib/components/ui/Text/README.mdx
+++ b/src/lib/components/ui/Text/README.mdx
@@ -78,10 +78,10 @@ appended by an ellipsis (`…`).
         <Toolbar align="baseline">
           <ToolbarItem>
             <TextField
-              changeHandler={(e) => setLines(e.target.value)}
               label="Number of lines"
               min={1}
               max={100}
+              onChange={(e) => setLines(e.target.value)}
               type="number"
               value={lines}
             />
@@ -156,19 +156,19 @@ will override automatic break point selection in `auto` mode when present.
             <ToolbarItem>
               <ButtonGroup aria-labelledby="#word-wrapping-options-label">
                 <Button
-                  label="normal"
-                  clickHandler={() => setWordWrapping('normal')}
                   color={wordWrapping === 'normal' ? 'dark' : 'primary'}
+                  label="normal"
+                  onClick={() => setWordWrapping('normal')}
                 />
                 <Button
-                  label="long-words"
-                  clickHandler={() => setWordWrapping('long-words')}
                   color={wordWrapping === 'long-words' ? 'dark' : 'primary'}
+                  label="long-words"
+                  onClick={() => setWordWrapping('long-words')}
                 />
                 <Button
-                  label="anywhere"
-                  clickHandler={() => setWordWrapping('anywhere')}
                   color={wordWrapping === 'anywhere' ? 'dark' : 'primary'}
+                  label="anywhere"
+                  onClick={() => setWordWrapping('anywhere')}
                 />
               </ButtonGroup>
             </ToolbarItem>
@@ -180,19 +180,19 @@ will override automatic break point selection in `auto` mode when present.
             <ToolbarItem>
               <ButtonGroup aria-labelledby="#hyphens-options-label">
                 <Button
-                  label="none"
-                  clickHandler={() => setHyphens('none')}
                   color={hyphens === 'none' ? 'dark' : 'primary'}
+                  label="none"
+                  onClick={() => setHyphens('none')}
                 />
                 <Button
-                  label="auto"
-                  clickHandler={() => setHyphens('auto')}
                   color={hyphens === 'auto' ? 'dark' : 'primary'}
+                  label="auto"
+                  onClick={() => setHyphens('auto')}
                 />
                 <Button
-                  label="manual"
-                  clickHandler={() => setHyphens('manual')}
                   color={hyphens === 'manual' ? 'dark' : 'primary'}
+                  label="manual"
+                  onClick={() => setHyphens('manual')}
                 />
               </ButtonGroup>
             </ToolbarItem>

--- a/src/lib/components/ui/TextArea/README.mdx
+++ b/src/lib/components/ui/TextArea/README.mdx
@@ -348,10 +348,10 @@ It's possible to disable the whole input.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `textarea` HTML element.
-This is useful mainly to improve component's
-[accessibility](#forwarding-html-attributes).
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `textarea` HTML element. This enables making the component
+interactive and helps improve its [accessibility](#forwarding-html-attributes).
 
 <Props table of={TextArea} />
 
@@ -359,3 +359,5 @@ This is useful mainly to improve component's
 
 Head to [Forms Theming](/customize/theming/forms) to see shared form theming
 options.
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/TextArea/TextArea.jsx
+++ b/src/lib/components/ui/TextArea/TextArea.jsx
@@ -10,7 +10,6 @@ import withForwardedRef from '../withForwardedRef';
 import styles from './TextArea.scss';
 
 export const TextArea = ({
-  changeHandler,
   cols,
   disabled,
   forwardedRef,
@@ -67,7 +66,6 @@ export const TextArea = ({
             cols={cols}
             disabled={disabled}
             id={id}
-            onChange={changeHandler}
             placeholder={placeholder}
             ref={forwardedRef}
             required={required}
@@ -100,7 +98,6 @@ export const TextArea = ({
 };
 
 TextArea.defaultProps = {
-  changeHandler: null,
   cols: null,
   disabled: false,
   forwardedRef: undefined,
@@ -120,10 +117,6 @@ TextArea.defaultProps = {
 };
 
 TextArea.propTypes = {
-  /**
-   * Function to call when the input has changed.
-   */
-  changeHandler: PropTypes.func,
   /**
    * The number of visible text columns for the control.
    */

--- a/src/lib/components/ui/TextArea/__tests__/TextArea.test.jsx
+++ b/src/lib/components/ui/TextArea/__tests__/TextArea.test.jsx
@@ -68,7 +68,7 @@ describe('rendering', () => {
     ...validationTextPropTest,
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 'content text',
       },
       (rootElement) => expect(within(rootElement).getByText('content text')),
@@ -87,12 +87,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls changeHandler() on typing', () => {
+  it('calls synthetic event onChange() on typing', () => {
     const spy = sinon.spy();
     render((
       <TextArea
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
         value="content-value"
       />
     ));

--- a/src/lib/components/ui/TextField/README.mdx
+++ b/src/lib/components/ui/TextField/README.mdx
@@ -491,10 +491,10 @@ It's possible to disable the whole input.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `input` HTML element.
-This is useful mainly to improve component's
-[accessibility](#forwarding-html-attributes).
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `input` HTML element. This enables making the component
+interactive and helps improve its [accessibility](#forwarding-html-attributes).
 
 <Props table of={TextField} />
 
@@ -513,3 +513,4 @@ Head to [Forms Theming][theming-forms] to see shared form theming options.
 [input-tel]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel
 [input-password]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password
 [theming-forms]: /customize/theming/forms
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/TextField/TextField.jsx
+++ b/src/lib/components/ui/TextField/TextField.jsx
@@ -12,7 +12,6 @@ import styles from './TextField.scss';
 const SMALL_INPUT_SIZE = 10;
 
 export const TextField = ({
-  changeHandler,
   disabled,
   forwardedRef,
   fullWidth,
@@ -71,7 +70,6 @@ export const TextField = ({
             className={styles.input}
             disabled={disabled}
             id={id}
-            onChange={changeHandler}
             placeholder={placeholder}
             ref={forwardedRef}
             required={required}
@@ -105,7 +103,6 @@ export const TextField = ({
 };
 
 TextField.defaultProps = {
-  changeHandler: null,
   disabled: false,
   forwardedRef: undefined,
   fullWidth: false,
@@ -125,10 +122,6 @@ TextField.defaultProps = {
 };
 
 TextField.propTypes = {
-  /**
-   * Function to call when the input has changed.
-   */
-  changeHandler: PropTypes.func,
   /**
    * If `true`, the input will be disabled.
    */

--- a/src/lib/components/ui/TextField/__tests__/TextField.test.jsx
+++ b/src/lib/components/ui/TextField/__tests__/TextField.test.jsx
@@ -97,14 +97,14 @@ describe('rendering', () => {
     ...validationTextPropTest,
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 'content text',
       },
       (rootElement) => expect(within(rootElement).getByRole('textbox')).toHaveDisplayValue('content text'),
     ],
     [
       {
-        changeHandler: () => {},
+        onChange: () => {},
         value: 111,
       },
       (rootElement) => expect(within(rootElement).getByRole('textbox')).toHaveDisplayValue('111'),
@@ -123,12 +123,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls changeHandler() on changing selected option', () => {
+  it('calls synthetic event onChange() on changing selected option', () => {
     const spy = sinon.spy();
     render((
       <TextField
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
         value="content-value"
       />
     ));

--- a/src/lib/components/ui/Toggle/README.mdx
+++ b/src/lib/components/ui/Toggle/README.mdx
@@ -29,9 +29,9 @@ And use it:
     const [studioQuality, setStudioQuality] = React.useState(true);
     return (
       <Toggle
-        changeHandler={() => setStudioQuality(!studioQuality)}
         checked={studioQuality}
         label="Listen in studio quality"
+        onChange={() => setStudioQuality(!studioQuality)}
       />
     );
   }}
@@ -75,13 +75,13 @@ turning the toggle on or off.
     const [studioQuality, setStudioQuality] = React.useState(true);
     return (
       <Toggle
-        changeHandler={() => setStudioQuality(!studioQuality)}
         checked={studioQuality}
         helpText={
           'Unrivaled audio quality. Uses the MQA audio format. '
           + 'Transfers a lot of data.'
         }
         label="Listen in studio quality"
+        onChange={() => setStudioQuality(!studioQuality)}
       />
     );
   }}
@@ -97,10 +97,10 @@ remains accessible to assistive technologies.
     const [studioQuality, setStudioQuality] = React.useState(true);
     return (
       <Toggle
-        changeHandler={() => setStudioQuality(!studioQuality)}
         checked={studioQuality}
         isLabelVisible={false}
         label="You cannot see this"
+        onChange={() => setStudioQuality(!studioQuality)}
       />
     );
   }}
@@ -113,10 +113,10 @@ It's also possible to display the label before the input:
     const [studioQuality, setStudioQuality] = React.useState(true);
     return (
       <Toggle
-        changeHandler={() => setStudioQuality(!studioQuality)}
         checked={studioQuality}
         label="Listen in studio quality"
         labelPosition="before"
+        onChange={() => setStudioQuality(!studioQuality)}
       />
     );
   }}
@@ -137,15 +137,15 @@ have.
     return (
       <>
         <Toggle
-          changeHandler={() => setStudioQuality(!studioQuality)}
           checked={studioQuality}
           label="Listen in studio quality"
+          onChange={() => setStudioQuality(!studioQuality)}
           validationState="valid"
         />
         <Toggle
-          changeHandler={() => setStudioQuality(!studioQuality)}
           checked={studioQuality}
           label="Listen in studio quality"
+          onChange={() => setStudioQuality(!studioQuality)}
           validationState="warning"
           validationText={
             'Looks like you are connected over cellular network. '
@@ -153,9 +153,9 @@ have.
           }
         />
         <Toggle
-          changeHandler={() => setStudioQuality(!studioQuality)}
           checked={studioQuality}
           label="Listen in studio quality"
+          onChange={() => setStudioQuality(!studioQuality)}
           validationState="invalid"
           validationText="Please upgrade your plan to make this option available."
         />
@@ -179,9 +179,10 @@ Disabled state makes the input unavailable.
 
 ## API
 
-In addition to the options below, you can add any custom attributes that do not
-interfere with the API, and they will be passed to the `input` HTML element.
-This is useful mainly to improve component's accessibility.
+In addition to the options below, you can specify [React synthetic events] or
+any custom HTML attributes that do not interfere with the API, and they will be
+passed to the `input` HTML element. This enables making the component
+interactive and helps improve its accessibility.
 
 <Props table of={Toggle} />
 
@@ -199,3 +200,5 @@ options. On top of that, the following options are available for Toggle.
 | `--rui-FormField--check__input--toggle--default__background-position` | Background position of unchecked input      |
 | `--rui-FormField--check__input--toggle--checked__background-image` | Background image of checked input              |
 | `--rui-FormField--check__input--toggle--checked__background-position` | Background position of checked input        |
+
+[React synthetic events]: https://reactjs.org/docs/events.html

--- a/src/lib/components/ui/Toggle/Toggle.jsx
+++ b/src/lib/components/ui/Toggle/Toggle.jsx
@@ -8,7 +8,6 @@ import withForwardedRef from '../withForwardedRef';
 import styles from './Toggle.scss';
 
 export const Toggle = ({
-  changeHandler,
   checked,
   disabled,
   forwardedRef,
@@ -47,7 +46,6 @@ export const Toggle = ({
           disabled={disabled}
           id={id}
           name={id}
-          onChange={changeHandler}
           ref={forwardedRef}
           required={required}
           type="checkbox"
@@ -84,7 +82,6 @@ export const Toggle = ({
 };
 
 Toggle.defaultProps = {
-  changeHandler: null,
   checked: undefined,
   disabled: false,
   forwardedRef: undefined,
@@ -99,10 +96,6 @@ Toggle.defaultProps = {
 };
 
 Toggle.propTypes = {
-  /**
-   * Function to call when the input is toggled.
-   */
-  changeHandler: PropTypes.func,
   /**
    * If `true`, the input will be checked.
    */

--- a/src/lib/components/ui/Toggle/__tests__/Toggle.test.jsx
+++ b/src/lib/components/ui/Toggle/__tests__/Toggle.test.jsx
@@ -27,15 +27,15 @@ describe('rendering', () => {
   it.each([
     [
       {
-        changeHandler: () => {},
         checked: true,
+        onChange: () => {},
       },
       (rootElement) => expect(within(rootElement).getByRole('checkbox')).toBeChecked(),
     ],
     [
       {
-        changeHandler: () => {},
         checked: false,
+        onChange: () => {},
       },
       (rootElement) => expect(within(rootElement).getByRole('checkbox')).not.toBeChecked(),
     ],
@@ -90,12 +90,12 @@ describe('rendering', () => {
 });
 
 describe('functionality', () => {
-  it('calls changeHandler() on toggling', () => {
+  it('calls synthetic event onChange() on toggling', () => {
     const spy = sinon.spy();
     render((
       <Toggle
         {...mandatoryProps}
-        changeHandler={spy}
+        onChange={spy}
       />
     ));
 

--- a/src/lib/provider/__tests__/RUIProvider.test.jsx
+++ b/src/lib/provider/__tests__/RUIProvider.test.jsx
@@ -20,7 +20,7 @@ describe('rendering', () => {
     ],
     [
       {
-        children: <Alert closeHandler={() => {}}>alert text</Alert>,
+        children: <Alert onClose={() => {}}>alert text</Alert>,
         translations: {
           Alert: { close: 'Zavřít' },
         },


### PR DESCRIPTION
Closes #218 