### PR TITLE
Extend `Button`'s `labelVisibility` with breakpoints (#273)

### DIFF
--- a/src/docs/css-helpers/typography.mdx
+++ b/src/docs/css-helpers/typography.mdx
@@ -27,7 +27,7 @@ classes:
 
 ## Text Alignment
 
-Try resizing your browser to see how the alignment below changes.
+📐 Try resizing your browser to see how the alignment below changes.
 
 <Playground>
   <div>

--- a/src/lib/components/layout/CTA/README.mdx
+++ b/src/lib/components/layout/CTA/README.mdx
@@ -63,7 +63,7 @@ See [API](#api) for all available options.
   screen even at the smallest size. For complex layouts and a lot of actions,
   consider using the [Toolbar](/components/layout/toolbar) layout.
 
-👉 On screen sizes smaller than 66 em (the `lg`
+📐 On screen sizes smaller than 66 em (the `lg`
 [breakpoint](/foundation/breakpoints)), the start element expands over the full
 width of its parent. Please resize your browser rather than the playground to
 see this work.

--- a/src/lib/components/layout/FormLayout/README.mdx
+++ b/src/lib/components/layout/FormLayout/README.mdx
@@ -135,7 +135,7 @@ with CSS custom properties.
 - The `custom` mode (local) allows you to enter any **custom label width for
   individual FormLayouts.**
 
-Try to resize the playground to see how individual options work.
+📐 Try resizing the playground to see how individual options work.
 
 <Playground>
   {() => {

--- a/src/lib/components/layout/Toolbar/README.mdx
+++ b/src/lib/components/layout/Toolbar/README.mdx
@@ -249,7 +249,7 @@ set the `nowrap` option on the Toolbar or on individual ToolbarGroups. Note that
 ToolbarGroups can still wrap when the wrapping is disabled just on their parent
 Toolbar.
 
-Try resizing the playground below to see how it works.
+📐 Try resizing the playground below to see how it works.
 
 <Playground>
   <>

--- a/src/lib/components/ui/Button/Button.jsx
+++ b/src/lib/components/ui/Button/Button.jsx
@@ -106,7 +106,7 @@ Button.defaultProps = {
   feedbackIcon: null,
   forwardedRef: undefined,
   id: undefined,
-  labelVisibility: 'all',
+  labelVisibility: 'xs',
   priority: 'filled',
   size: 'medium',
   startCorner: null,
@@ -173,9 +173,9 @@ Button.propTypes = {
    */
   label: PropTypes.string.isRequired,
   /**
-   * Defines when the button label should be visible.
+   * Defines minimum breakpoint from which the button label will be visible.
    */
-  labelVisibility: PropTypes.oneOf(['all', 'desktop', 'none']),
+  labelVisibility: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'none']),
   /**
    * Visual priority to highlight or suppress the button.
    *

--- a/src/lib/components/ui/Button/README.mdx
+++ b/src/lib/components/ui/Button/README.mdx
@@ -157,19 +157,50 @@ before or after the button's label.
 ### Icon Buttons
 
 For clear and simple actions, buttons can visually consist just of an icon.
-Label remains mandatory to keep the button accessible. Icon buttons can
-optionally enhance on desktop and display the label once there is enough room
-for it.
+Label remains mandatory to keep the button accessible.
 
 <Playground>
   <Button
     label="Icon button"
     labelVisibility="none"
-    afterLabel={<Icon icon="pencil" />}
+    beforeLabel={<Icon icon="pencil" />}
+  />
+</Playground>
+
+Icon buttons can optionally enhance on a [breakpoint](/foundation/breakpoints)
+of your choice and display label once you know there is enough room for it.
+
+📐 Try resizing your browser to see how label visibility changes.
+
+<Playground>
+  <Button
+    label="Label visible from sm up"
+    labelVisibility="sm"
+    beforeLabel={<Icon icon="pencil" />}
   />
   <Button
-    label="Icon button with label visible on desktop"
-    labelVisibility="desktop"
+    label="Label visible from md up"
+    labelVisibility="md"
+    beforeLabel={<Icon icon="pencil" />}
+  />
+  <Button
+    label="Label visible from lg up"
+    labelVisibility="lg"
+    beforeLabel={<Icon icon="pencil" />}
+  />
+  <Button
+    label="Label visible from xl up"
+    labelVisibility="xl"
+    beforeLabel={<Icon icon="pencil" />}
+  />
+  <Button
+    label="Label visible from xxl up"
+    labelVisibility="xxl"
+    beforeLabel={<Icon icon="pencil" />}
+  />
+  <Button
+    label="Label visible from xxxl up"
+    labelVisibility="xxxl"
     beforeLabel={<Icon icon="pencil" />}
   />
 </Playground>

--- a/src/lib/components/ui/Button/__tests__/Button.test.jsx
+++ b/src/lib/components/ui/Button/__tests__/Button.test.jsx
@@ -102,15 +102,28 @@ describe('rendering', () => {
     ],
     ...labelPropTest,
     [
-      { labelVisibility: 'all' },
-      (rootElement) => {
-        expect(rootElement).not.toHaveClass('withLabelHiddenMobile');
-        expect(rootElement).not.toHaveClass('withLabelHidden');
-      },
+      { labelVisibility: 'sm' },
+      (rootElement) => expect(rootElement).toHaveClass('withLabelVisibleSm'),
     ],
     [
-      { labelVisibility: 'desktop' },
-      (rootElement) => expect(rootElement).toHaveClass('withLabelHiddenMobile'),
+      { labelVisibility: 'md' },
+      (rootElement) => expect(rootElement).toHaveClass('withLabelVisibleMd'),
+    ],
+    [
+      { labelVisibility: 'lg' },
+      (rootElement) => expect(rootElement).toHaveClass('withLabelVisibleLg'),
+    ],
+    [
+      { labelVisibility: 'xl' },
+      (rootElement) => expect(rootElement).toHaveClass('withLabelVisibleXl'),
+    ],
+    [
+      { labelVisibility: 'xxl' },
+      (rootElement) => expect(rootElement).toHaveClass('withLabelVisibleXxl'),
+    ],
+    [
+      { labelVisibility: 'xxxl' },
+      (rootElement) => expect(rootElement).toHaveClass('withLabelVisibleXxxl'),
     ],
     [
       { labelVisibility: 'none' },

--- a/src/lib/components/ui/Button/_base.scss
+++ b/src/lib/components/ui/Button/_base.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../../../styles/tools/accessibility';
 @use '../../../styles/tools/breakpoint';
 @use 'settings';
 @use 'theme';
@@ -66,12 +65,6 @@
   width: 100%;
 }
 
-.rootBlock.withLabelHiddenMobile {
-  @include breakpoint.up(settings.$breakpoint) {
-    width: 100%;
-  }
-}
-
 .hasRootFeedback:disabled {
   opacity: theme.$feedback-opacity;
   cursor: theme.$feedback-cursor;
@@ -108,29 +101,48 @@
   z-index: map.get(settings.$group-z-indexes, button-overflowing-elements);
 }
 
-.withLabelHidden .label,
-.withLabelHiddenMobile .label {
-  @include accessibility.hide-text();
+.withLabelHidden,
+.withLabelVisibleSm,
+.withLabelVisibleMd,
+.withLabelVisibleLg,
+.withLabelVisibleXl,
+.withLabelVisibleXxl,
+.withLabelVisibleXxxl {
+  @include tools.hide-label();
 }
 
-.withLabelHiddenMobile .label {
-  @include breakpoint.up(settings.$breakpoint) {
-    position: relative;
-    width: auto;
-    height: auto;
+.withLabelVisibleSm {
+  @include breakpoint.up(sm) {
+    @include tools.show-label();
   }
 }
 
-.withLabelHidden.isRootLoading .beforeLabel,
-.withLabelHidden.isRootLoading .afterLabel,
-.withLabelHiddenMobile.isRootLoading .beforeLabel,
-.withLabelHiddenMobile.isRootLoading .afterLabel {
-  display: none;
+.withLabelVisibleMd {
+  @include breakpoint.up(md) {
+    @include tools.show-label();
+  }
 }
 
-.withLabelHiddenMobile.isRootLoading .beforeLabel,
-.withLabelHiddenMobile.isRootLoading .afterLabel {
-  @include breakpoint.up(settings.$breakpoint) {
-    display: flex;
+.withLabelVisibleLg {
+  @include breakpoint.up(lg) {
+    @include tools.show-label();
+  }
+}
+
+.withLabelVisibleXl {
+  @include breakpoint.up(xl) {
+    @include tools.show-label();
+  }
+}
+
+.withLabelVisibleXxl {
+  @include breakpoint.up(xxl) {
+    @include tools.show-label();
+  }
+}
+
+.withLabelVisibleXxxl {
+  @include breakpoint.up(xxxl) {
+    @include tools.show-label();
   }
 }

--- a/src/lib/components/ui/Button/_settings.scss
+++ b/src/lib/components/ui/Button/_settings.scss
@@ -4,7 +4,6 @@
 $font-family: typography.$font-family-base;
 $line-height: typography.$line-height-base;
 $icon-spacing: spacing.of(2);
-$breakpoint: lg;
 
 $group-z-indexes: (
   button: auto,

--- a/src/lib/components/ui/Button/_tools.scss
+++ b/src/lib/components/ui/Button/_tools.scss
@@ -12,10 +12,13 @@
 // 3. Get ready for position of corner elements and group separator.
 //
 // 4. Icon buttons should appear as squares, that's why width and height is equal here.
+//
+// 5. Use original padding to restore square buttons back to their size.
 
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
+@use '../../../styles/tools/accessibility';
 @use '../../../styles/tools/breakpoint';
 @use '../../../styles/tools/transition';
 @use 'settings';
@@ -58,6 +61,18 @@
   }
 }
 
+// 4.
+@mixin _button-square() {
+  --rui-local-padding: 0;
+  --rui-local-width: var(--rui-local-height);
+}
+
+// 5.
+@mixin _button-size-restore() {
+  --rui-local-padding: var(--rui-local-padding-original);
+  --rui-local-width: unset;
+}
+
 @mixin button() {
   @include transition.add((opacity, color, border-color, background-color, box-shadow));
 
@@ -73,7 +88,6 @@
   letter-spacing: theme.$letter-spacing;
   text-align: center;
   text-decoration: none;
-  text-overflow: ellipsis;
   text-transform: theme.$text-transform;
   vertical-align: middle;
   color: var(--rui-local-color);
@@ -104,20 +118,8 @@
 
   --rui-local-height: #{map.get($properties, height)};
   --rui-local-padding: 0 #{map.get($properties, padding-x)};
+  --rui-local-padding-original: 0 #{map.get($properties, padding-x)}; // 5.
   --rui-local-font-size: #{map.get($properties, font-size)};
-
-  &.withLabelHidden,
-  &.withLabelHiddenMobile {
-    --rui-local-padding: 0;
-    --rui-local-width: #{map.get($properties, height)}; // 4.
-  }
-
-  &.withLabelHiddenMobile {
-    @include breakpoint.up(settings.$breakpoint) {
-      --rui-local-padding: 0 #{map.get($properties, padding-x)};
-      --rui-local-width: auto;
-    }
-  }
 }
 
 @mixin button-color($priority, $color) {
@@ -134,5 +136,21 @@
 
   &:not(:disabled):active {
     @include _get-themeable-properties($priority, $color, active);
+  }
+}
+
+@mixin hide-label() {
+  @include _button-square();
+
+  .label {
+    @include accessibility.hide-text();
+  }
+}
+
+@mixin show-label() {
+  @include _button-size-restore();
+
+  .label {
+    @include accessibility.unhide-text();
   }
 }

--- a/src/lib/components/ui/Button/helpers/getRootLabelVisibilityClassName.js
+++ b/src/lib/components/ui/Button/helpers/getRootLabelVisibilityClassName.js
@@ -1,6 +1,28 @@
 export default (labelVisibility, styles) => {
-  if (labelVisibility === 'desktop') {
-    return styles.withLabelHiddenMobile;
+  // Intentionally omitting `xs` which means label is visible on all screen sizes.
+
+  if (labelVisibility === 'sm') {
+    return styles.withLabelVisibleSm;
+  }
+
+  if (labelVisibility === 'md') {
+    return styles.withLabelVisibleMd;
+  }
+
+  if (labelVisibility === 'lg') {
+    return styles.withLabelVisibleLg;
+  }
+
+  if (labelVisibility === 'xl') {
+    return styles.withLabelVisibleXl;
+  }
+
+  if (labelVisibility === 'xxl') {
+    return styles.withLabelVisibleXxl;
+  }
+
+  if (labelVisibility === 'xxxl') {
+    return styles.withLabelVisibleXxxl;
   }
 
   if (labelVisibility === 'none') {

--- a/src/lib/styles/tools/_accessibility.scss
+++ b/src/lib/styles/tools/_accessibility.scss
@@ -17,6 +17,15 @@
   border: 0;
 }
 
+@mixin unhide-text() {
+  position: unset;
+  width: unset;
+  height: unset;
+  overflow: unset;
+  clip: unset;
+  white-space: unset;
+}
+
 // 2.
 @mixin min-tap-target($size: theme.$tap-target-size, $center: true) {
   position: relative;


### PR DESCRIPTION
<img width="859" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/139121970-0efd33bb-a665-4bbd-b8fa-6dac0e2d6bac.png">

<img width="855" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/139122132-d671c7b0-a53c-4f80-bbe6-ff4051349de5.png">

Closes #273.