### PR TITLE
Ease PropType validation of the `children` prop to allow passing in nonrenderable `false` and `null` values (#332)

### DIFF
--- a/src/lib/components/CTA/CTA.jsx
+++ b/src/lib/components/CTA/CTA.jsx
@@ -52,10 +52,7 @@ CTA.propTypes = {
    * * `CTACenter`
    * * `CTAEnd`
    */
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 export const CTAWithContext = withProviderContext(CTA, 'CTA');

--- a/src/lib/components/Card/Card.jsx
+++ b/src/lib/components/Card/Card.jsx
@@ -41,10 +41,7 @@ Card.propTypes = {
    * * `CardFooter`
    * * `ScrollView`
    */
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
+  children: PropTypes.node.isRequired,
   /**
    * [Color variant](/foundation/colors#component-colors) to clarify importance and meaning of the card.
    */

--- a/src/lib/components/FormLayout/FormLayout.jsx
+++ b/src/lib/components/FormLayout/FormLayout.jsx
@@ -89,10 +89,7 @@ FormLayout.propTypes = {
    * * `TextField`
    * * `Toggle`
    */
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]),
+  children: PropTypes.node,
   /**
    * Layout that is forced on children form fields.
    */

--- a/src/lib/components/Media/Media.jsx
+++ b/src/lib/components/Media/Media.jsx
@@ -21,10 +21,7 @@ Media.propTypes = {
    * * `MediaBody`
    * * `MediaObject`
    */
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 export const MediaWithContext = withProviderContext(Media, 'Media');

--- a/src/lib/components/Tabs/Tabs.jsx
+++ b/src/lib/components/Tabs/Tabs.jsx
@@ -26,10 +26,7 @@ Tabs.propTypes = {
   /**
    * Nested `TabsItem` elements.
    */
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]),
+  children: PropTypes.node,
   /**
    * ID of the root HTML element. It also serves as base for nested element:
    * * `<ID>__list`


### PR DESCRIPTION
Closes # 332