### PR TITLE
Fix custom input size of `TextField`

### DIFF
--- a/src/lib/components/TextField/TextField.jsx
+++ b/src/lib/components/TextField/TextField.jsx
@@ -40,6 +40,7 @@ export const TextField = ({
         styles.root,
         fullWidth ? styles.isRootFullWidth : '',
         hasSmallInput ? styles.hasRootSmallInput : '',
+        inputSize ? styles.hasRootCustomInputSize : '',
         context ? styles.isRootInFormLayout : '',
         resolveContextOrProp(context && context.layout, layout) === 'horizontal'
           ? styles.rootLayoutHorizontal

--- a/src/lib/components/TextField/__tests__/TextField.test.jsx
+++ b/src/lib/components/TextField/__tests__/TextField.test.jsx
@@ -61,6 +61,7 @@ describe('rendering', () => {
       },
       (rootElement) => {
         expect(within(rootElement).getByLabelText('label')).not.toHaveAttribute('size');
+        expect(rootElement).toHaveClass('hasRootCustomInputSize');
         expect(rootElement).toHaveStyle('--rui-custom-input-size: 3');
       },
     ],


### PR DESCRIPTION
Fixing a bug caused by accidental line deletion introduced in PR #318.

## What was reviewed

Line deletion is [not present in the diff](https://github.com/react-ui-org/react-ui/pull/318/files#diff-cbad86635207378f7dc7cf04fa71f5f3dd595b1a546d8c4ac73ade4998e71687L43).

<img width="1258" alt="Snímek obrazovky 2021-12-20 v 18 01 27" src="https://user-images.githubusercontent.com/5614085/146807104-7fdb1534-cbe5-4755-a0b2-e15c883b6dfb.png">

## What was merged

However, it [is present in the final commit](https://github.com/react-ui-org/react-ui/commit/986356f815862e9d97f68f45c8447f2b64b9b41b#diff-cbad86635207378f7dc7cf04fa71f5f3dd595b1a546d8c4ac73ade4998e71687L43) (screenshot from SourceTree).

<img width="907" alt="Snímek obrazovky 2021-12-20 v 18 03 02" src="https://user-images.githubusercontent.com/5614085/146807209-f0a9437e-1ac0-4431-8721-20f7cc3abe55.png">