### PR TITLE
Vertically expand `Button`s with long labels to prevent overflow

### DIFF
--- a/src/docs/foundation/typography.mdx
+++ b/src/docs/foundation/typography.mdx
@@ -76,6 +76,7 @@ Font size and weight values can be customised as well:
 :root {
   --rui-typography-font-size-base: 100%;
   --rui-typography-line-height-base: 1.5;
+  --rui-typography-line-height-small: 1.25;
   --rui-typography-size-0: 1rem;
   --rui-typography-size-1: 1.125rem;
   --rui-typography-size-2: 1.266rem;

--- a/src/lib/components/Alert/_settings.scss
+++ b/src/lib/components/Alert/_settings.scss
@@ -3,5 +3,5 @@
 @use 'theme';
 
 $font-size: map.get(typography.$size-values, 0);
-$line-height: 1.5;
+$line-height: typography.$line-height-base;
 $min-height: calc(#{$font-size} * #{$line-height} + 2 * #{theme.$padding});

--- a/src/lib/components/Button/README.mdx
+++ b/src/lib/components/Button/README.mdx
@@ -448,7 +448,7 @@ Where:
 
 - `<SIZE>` is one of `small`, `medium`, or `large` (see [Sizes](#sizes) and
   [API](#api))
-- `<PROPERTY>` is one of `height`, `padding-x`, or `font-size`
+- `<PROPERTY>` is one of `height`, `padding-x`, `padding-y`, or `font-size`
 
 ### Example Theme
 
@@ -464,6 +464,7 @@ Where:
           0.1em 0.1em 0.5em rgba(0, 0, 0, 0.3);
         --rui-Button--medium__height: 3rem;
         --rui-Button--medium__padding-x: 1.25rem;
+        --rui-Button--medium__padding-y: 0.25rem;
       }
     `}
   </style>

--- a/src/lib/components/Button/_settings.scss
+++ b/src/lib/components/Button/_settings.scss
@@ -2,7 +2,7 @@
 @use '../../styles/tools/spacing';
 
 $font-family: typography.$font-family-base;
-$line-height: typography.$line-height-base;
+$line-height: typography.$line-height-small;
 $icon-spacing: spacing.of(2);
 
 $group-z-indexes: (

--- a/src/lib/components/Button/_theme.scss
+++ b/src/lib/components/Button/_theme.scss
@@ -26,16 +26,19 @@ $sizes: (
   small: (
     height: var(--rui-Button--small__height),
     padding-x: var(--rui-Button--small__padding-x),
+    padding-y: var(--rui-Button--small__padding-y),
     font-size: var(--rui-Button--small__font-size),
   ),
   medium: (
     height: var(--rui-Button--medium__height),
     padding-x: var(--rui-Button--medium__padding-x),
+    padding-y: var(--rui-Button--medium__padding-y),
     font-size: var(--rui-Button--medium__font-size),
   ),
   large: (
     height: var(--rui-Button--large__height),
     padding-x: var(--rui-Button--large__padding-x),
+    padding-y: var(--rui-Button--large__padding-y),
     font-size: var(--rui-Button--large__font-size),
   ),
 );

--- a/src/lib/components/Button/_tools.scss
+++ b/src/lib/components/Button/_tools.scss
@@ -82,7 +82,7 @@
   align-items: center;
   justify-content: center;
   width: var(--rui-local-width, auto);
-  height: var(--rui-local-height, auto);
+  min-height: var(--rui-local-height, auto);
   padding: var(--rui-local-padding);
   font: theme.$font-weight list.slash(var(--rui-local-font-size), settings.$line-height) settings.$font-family;
   letter-spacing: theme.$letter-spacing;
@@ -117,8 +117,8 @@
   $properties: map.get(theme.$sizes, $size);
 
   --rui-local-height: #{map.get($properties, height)};
-  --rui-local-padding: 0 #{map.get($properties, padding-x)};
-  --rui-local-padding-original: 0 #{map.get($properties, padding-x)}; // 5.
+  --rui-local-padding: #{map.get($properties, padding-y)} #{map.get($properties, padding-x)};
+  --rui-local-padding-original: #{map.get($properties, padding-y)} #{map.get($properties, padding-x)}; // 5.
   --rui-local-font-size: #{map.get($properties, font-size)};
 }
 

--- a/src/lib/styles/theme/_typography.scss
+++ b/src/lib/styles/theme/_typography.scss
@@ -21,3 +21,4 @@ $size-smaller: var(--rui-typography-size-smaller);
 $font-family-base: var(--rui-typography-font-family-base);
 $font-size-base: var(--rui-typography-font-size-base);
 $line-height-base: var(--rui-typography-line-height-base);
+$line-height-small: var(--rui-typography-line-height-small);

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -121,6 +121,7 @@
   --rui-typography-font-family-base: 'Titillium Web', helvetica, roboto, arial, sans-serif;
   --rui-typography-font-size-base: 100%;
   --rui-typography-line-height-base: 1.5;
+  --rui-typography-line-height-small: 1.25;
   --rui-typography-size-0: 1rem;
   --rui-typography-size-1: 1.125rem;
   --rui-typography-size-2: 1.266rem;
@@ -642,16 +643,19 @@
 
   // Buttons: sizes: small
   --rui-Button--small__height: 1.75rem;
+  --rui-Button--small__padding-y: var(--rui-spacing-1);
   --rui-Button--small__padding-x: var(--rui-spacing-3);
   --rui-Button--small__font-size: var(--rui-typography-size-small);
 
   // Buttons: sizes: medium
   --rui-Button--medium__height: 2.25rem;
+  --rui-Button--medium__padding-y: var(--rui-spacing-1);
   --rui-Button--medium__padding-x: var(--rui-spacing-4);
   --rui-Button--medium__font-size: var(--rui-typography-size-0);
 
   // Buttons: sizes: large
   --rui-Button--large__height: 2.75rem;
+  --rui-Button--large__padding-y: var(--rui-spacing-2);
   --rui-Button--large__padding-x: var(--rui-spacing-5);
   --rui-Button--large__font-size: var(--rui-typography-size-1);
 


### PR DESCRIPTION
New theming options:

- `--rui-typography-line-height-small`
- `--rui-Button--small__padding-y`
- `--rui-Button--medium__padding-y`
- `--rui-Button--large__padding-y`

Before:

<img width="294" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/148799407-c2f887ab-cf42-432c-bb06-a81defeb0130.png">

After:

<img width="291" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/148799366-230b826e-aa50-472a-a48e-c034e268d668.png">
