### PR TITLE
Link sizes of box form fields to `Button` sizes to make customisation easier

### DIFF
--- a/src/docs/customize/theming/forms.mdx
+++ b/src/docs/customize/theming/forms.mdx
@@ -226,6 +226,10 @@ Where:
 - `<SIZE>` is one of `small`, `medium`, or `large`
 - `<PROPERTY>` is one of `height`, `padding-x`, `padding-y`, or `font-size`
 
+👉 Box field sizes are linked to
+[Button sizes](/components/button#theming-sizes) so they align nicely when
+placed in row.
+
 Example:
 
 <Playground>

--- a/src/lib/components/Button/README.mdx
+++ b/src/lib/components/Button/README.mdx
@@ -450,6 +450,10 @@ Where:
   [API](#api))
 - `<PROPERTY>` is one of `height`, `padding-x`, `padding-y`, or `font-size`
 
+👉 Button sizes are linked to
+[box field sizes](/customize/theming/forms#box-field-sizes) sizes so they align
+nicely when placed in row.
+
 ### Example Theme
 
 <Playground>

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -804,19 +804,19 @@
   --rui-FormField--box--select__option--disabled__color: var(--rui-color-gray-300);
 
   // Form fields: box field sizes: small
-  --rui-FormField--box--small__height: 1.75rem;
+  --rui-FormField--box--small__height: var(--rui-Button--small__height);
   --rui-FormField--box--small__padding-y: 0.0625rem;
   --rui-FormField--box--small__padding-x: var(--rui-spacing-2);
   --rui-FormField--box--small__font-size: var(--rui-typography-size-small);
 
   // Form fields: box field sizes: medium
-  --rui-FormField--box--medium__height: 2.25rem;
+  --rui-FormField--box--medium__height: var(--rui-Button--medium__height);
   --rui-FormField--box--medium__padding-y: 0.3125rem;
   --rui-FormField--box--medium__padding-x: var(--rui-spacing-3);
   --rui-FormField--box--medium__font-size: var(--rui-typography-size-0);
 
   // Form fields: box field sizes: large
-  --rui-FormField--box--large__height: 2.75rem;
+  --rui-FormField--box--large__height: var(--rui-Button--large__height);
   --rui-FormField--box--large__padding-y: 0.5625rem;
   --rui-FormField--box--large__padding-x: var(--rui-spacing-4);
   --rui-FormField--box--large__font-size: var(--rui-typography-size-1);


### PR DESCRIPTION
Useful for typical use case of input and button in row.

- [x] Swap destination to `master` once #355 is merged.