### PR TITLE
Display labels of inline form fields in the same `FormLayout` column as other labels (#323)

### DIFF
--- a/src/lib/components/CheckboxField/CheckboxField.jsx
+++ b/src/lib/components/CheckboxField/CheckboxField.jsx
@@ -40,6 +40,15 @@ export const CheckboxField = ({
       id={id && `${id}__label`}
     >
       <div className={styles.field}>
+        <div
+          className={classNames(
+            styles.label,
+            !isLabelVisible && styles.isLabelHidden,
+          )}
+          id={id && `${id}__labelText`}
+        >
+          {label}
+        </div>
         <input
           {...transferProps(restProps)}
           checked={checked}
@@ -51,15 +60,6 @@ export const CheckboxField = ({
           type="checkbox"
           value={value}
         />
-        <div
-          className={classNames(
-            styles.label,
-            !isLabelVisible && styles.isLabelHidden,
-          )}
-          id={id && `${id}__labelText`}
-        >
-          {label}
-        </div>
       </div>
       {helpText && (
         <div

--- a/src/lib/components/CheckboxField/CheckboxField.scss
+++ b/src/lib/components/CheckboxField/CheckboxField.scss
@@ -17,7 +17,7 @@
 }
 
 .field {
-    @include inline-field-layout.field();
+    @include inline-field-layout.field($type: checkbox);
 }
 
 .input {

--- a/src/lib/components/FormLayout/README.mdx
+++ b/src/lib/components/FormLayout/README.mdx
@@ -200,20 +200,17 @@ with CSS custom properties.
 
 ### Limitations
 
+#### Label Position
+
+Label position of inline form fields (CheckboxField, Toggle) is ignored in
+horizontal FormLayout.
+
 #### Modals
 
 Please note the `auto` and `limited` label width options may not function
 correctly in combination with other auto layout mechanisms, e.g. the auto-width
-[Modal](/components/modal). It's just too much of magic that doesn't quite
+[Modal](/components/modal). It's just too much of magic that does not quite
 work together yet 🎩.
-
-#### Inline Form Fields
-
-CheckboxField and Toggle always display their labels after inputs inside
-FormLayout. In other words, their labels never appear in a column with other
-fields' labels even when they have `labelPosition` set to `before`. This feature
-[will be implemented][rui-232] once [CSS subgrid][subgrid] is fully supported in
-[browsers that we support](/getting-started/browsers-and-devices).
 
 ## Custom Fields
 
@@ -402,6 +399,7 @@ This is a demo of all components supported by FormLayout.
             </FormLayoutCustomField>
             <CheckboxField
               checked={isDeliveryAddress}
+              helpText="Uncheck if you wish to deliver to a different address."
               label="This is my delivery address"
               onChange={() => setIsDeliveryAddress(!isDeliveryAddress)}
             />

--- a/src/lib/components/Radio/Radio.scss
+++ b/src/lib/components/Radio/Radio.scss
@@ -24,7 +24,7 @@
 }
 
 .option {
-    @include inline-field-layout.field();
+    @include inline-field-layout.field($type: radio);
     @include inline-field-elements.min-tap-target($type: radio);
 }
 

--- a/src/lib/components/Toggle/Toggle.jsx
+++ b/src/lib/components/Toggle/Toggle.jsx
@@ -40,6 +40,15 @@ export const Toggle = ({
       id={id && `${id}__label`}
     >
       <div className={styles.field}>
+        <div
+          className={classNames(
+            styles.label,
+            !isLabelVisible && styles.isLabelHidden,
+          )}
+          id={id && `${id}__labelText`}
+        >
+          {label}
+        </div>
         <input
           {...transferProps(restProps)}
           checked={checked}
@@ -52,15 +61,6 @@ export const Toggle = ({
           type="checkbox"
           value={value}
         />
-        <div
-          className={classNames(
-            styles.label,
-            !isLabelVisible && styles.isLabelHidden,
-          )}
-          id={id && `${id}__labelText`}
-        >
-          {label}
-        </div>
       </div>
       {helpText && (
         <div

--- a/src/lib/components/Toggle/Toggle.scss
+++ b/src/lib/components/Toggle/Toggle.scss
@@ -17,7 +17,7 @@
 }
 
 .field {
-    @include inline-field-layout.field();
+    @include inline-field-layout.field($type: toggle);
 }
 
 .input {

--- a/src/lib/styles/tools/_reset.scss
+++ b/src/lib/styles/tools/_reset.scss
@@ -25,6 +25,9 @@
 
 @mixin list() {
     padding-left: 0;
-    margin-bottom: 0;
     list-style: none;
+
+    &:not(:last-child) {
+        margin-bottom: 0;
+    }
 }

--- a/src/lib/styles/tools/form-fields/_box-field-layout.scss
+++ b/src/lib/styles/tools/form-fields/_box-field-layout.scss
@@ -5,9 +5,9 @@
 // 2.  Form fields in horizontal layout also take up only as much space as they need. Labels do not
 //     wrap until label width limit is reached (50 % of available horizontal space by default).
 //
-// 3. Help texts and validation messages are aligned below input and wrapped. Their width is always
-//    limited to the width of the input field so they don't shift adjacent elements when they show
-//    up. This applies unless the field is inside FormLayout (see 10).
+// 3.  Help texts and validation messages are aligned below input and wrapped. Their width is always
+//     limited to the width of the input field so they don't shift adjacent elements when they show
+//     up. This applies unless the field is inside FormLayout (see 10).
 //
 // 4.  Define grid spacing as padding of child elements because grid areas make row and column gaps
 //     show up even when not necessary.

--- a/src/lib/styles/tools/form-fields/_inline-field-elements.scss
+++ b/src/lib/styles/tools/form-fields/_inline-field-elements.scss
@@ -6,6 +6,8 @@
 //
 // 3. Reset extra space previously added to symmetrically pad the field in FormLayout context as
 //    there already is a sufficient row gap provided by FormLayout.
+//
+// 4. Destroy tap target when subgrid is not supported.
 
 @use "../../theme/typography";
 @use "../../theme/form-fields" as theme;
@@ -93,7 +95,16 @@
             padding-top: 0;
 
             &::before {
-                top: calc((#{typography.$line-height-base} - 1rem * #{theme.$check-tap-target-size}) / 2);
+                top: calc((1rem * #{typography.$line-height-base} - #{theme.$check-tap-target-size}) / 2);
+            }
+        }
+
+        &.isRootInFormLayout.rootLayoutHorizontal::before {
+            grid-column-start: 2;
+
+            // 4.
+            @supports not (grid-template-columns: subgrid) {
+                display: none;
             }
         }
     }

--- a/src/lib/styles/tools/form-fields/_inline-field-layout.scss
+++ b/src/lib/styles/tools/form-fields/_inline-field-layout.scss
@@ -10,6 +10,7 @@
 
 @use "../../settings/forms";
 @use "../../settings/form-fields" as settings;
+@use "../../theme/form-fields" as theme;
 @use "../../theme/typography";
 @use "../breakpoint";
 
@@ -27,10 +28,17 @@
     }
 }
 
-@mixin field() {
+@mixin field($type) {
     display: flex; // 1.
     align-items: flex-start;
     min-width: 0; // 1.
+
+    @if $type == "radio" {
+        flex-direction: row;
+    } @else {
+        flex-direction: row-reverse;
+        justify-content: flex-end;
+    }
 
     .input {
         flex: none;
@@ -45,7 +53,7 @@
 
 @mixin has-label-before() {
     .field {
-        flex-direction: row-reverse;
+        flex-direction: row;
     }
 
     .label,
@@ -62,12 +70,45 @@
 
     @include breakpoint.up(forms.$horizontal-breakpoint) {
         &.rootLayoutHorizontal {
+            grid: inherit;
+            grid-template-columns: subgrid;
+            grid-column: span 2;
+
+            @supports not (grid-template-columns: subgrid) {
+                display: contents;
+            }
+        }
+
+        &.rootLayoutHorizontal .field {
+            display: contents;
+        }
+
+        &.rootLayoutHorizontal .label {
+            grid-column-start: 1;
+            width: auto;
+            padding-right: settings.$horizontal-inner-gap;
+            margin-left: 0;
+            text-align: theme.$horizontal-label-text-align;
+        }
+
+        &.rootLayoutHorizontal .input,
+        &.rootLayoutHorizontal .helpText,
+        &.rootLayoutHorizontal .validationText {
             grid-column-start: 2;
         }
 
-        &.rootLayoutHorizontal .label,
-        &.rootLayoutHorizontal .optionLabel {
-            width: auto; // 1.
+        &.rootLayoutHorizontal .helpText,
+        &.rootLayoutHorizontal .validationText {
+            width: auto;
+            max-width: 100%;
+
+            @supports not (grid-template-columns: subgrid) {
+                margin-top: calc(-1 * var(--rui-FormLayout__row-gap));
+            }
+        }
+
+        &.rootLayoutHorizontal.hasRootLabelBefore .label {
+            margin-right: 0;
         }
     }
 }


### PR DESCRIPTION
Affects `CheckboxField` and `Toggle`.

Closes #323.

<img width="792" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/167834160-dc941c90-f079-499a-af3d-e979fbece47c.png">
