### PR TITLE
Refactor `Toolbar` to use `gap` property for spacing between items (#333)

### DIFF
--- a/src/lib/components/Toolbar/Toolbar.scss
+++ b/src/lib/components/Toolbar/Toolbar.scss
@@ -7,19 +7,17 @@
 .group {
     display: flex;
     flex-wrap: wrap;
+    gap: theme.$gap;
 }
 
 .toolbar {
-    @include spacing.bottom(layouts, $compensation: theme.$gap);
-
-    margin: calc(-1 * #{theme.$gap});
+    @include spacing.bottom(layouts);
 }
 
 .item {
     display: flex; // 1.
     flex: none;
     flex-direction: column; // 1.
-    margin: theme.$gap;
 }
 
 .isItemFlexible {
@@ -59,16 +57,9 @@
     justify-content: space-between;
 }
 
-.isDense {
-    margin: calc(-1 * #{theme.$gap-dense});
-}
-
-.isDense .item {
-    margin: theme.$gap-dense;
-}
-
-.isDense > .isDense {
-    margin: 0;
+.isDense,
+.isDense .group {
+    gap: theme.$gap-dense;
 }
 
 .isNowrap {
@@ -77,13 +68,4 @@
 
 .isNowrap > .item:not(.isItemFlexible) {
     flex: 0 1 auto;
-}
-
-.toolbar.isDense {
-    @include spacing.bottom(layouts, $compensation: theme.$gap-dense);
-}
-
-.toolbar:not(.isDense) > .isDense,
-.group:not(.isDense) > .isDense {
-    margin: theme.$gap-dense;
 }

--- a/src/lib/styles/tools/_spacing.scss
+++ b/src/lib/styles/tools/_spacing.scss
@@ -11,17 +11,13 @@
     }
 }
 
-@mixin bottom($category: default, $compensation: null) {
+@mixin bottom($category: default) {
     @if not map.has-key(spacing.$bottom, $category) {
         @error "Invalid spacing category specified! #{$category} doesn't exist. "
             + "Choose one of #{map.keys(spacing.$bottom)}.";
     }
 
     &:not(:last-child) {
-        @if $compensation {
-            margin-bottom: calc(#{map.get(spacing.$bottom, $category)} - #{$compensation});
-        } @else {
-            margin-bottom: map.get(spacing.$bottom, $category);
-        }
+        margin-bottom: map.get(spacing.$bottom, $category);
     }
 }

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -219,8 +219,8 @@
     // Toolbar
     // =======
 
-    --rui-Toolbar__gap: var(--rui-spacing-2);
-    --rui-Toolbar__gap--dense: var(--rui-spacing-1);
+    --rui-Toolbar__gap: var(--rui-spacing-4);
+    --rui-Toolbar__gap--dense: var(--rui-spacing-2);
 
     // ============================================================================================ //
     // 3. UI COMPONENTS                                                                             //


### PR DESCRIPTION
⚠️ Visual result remains the same, but it's necessary to **revisit margins** of neighboring elements in downstream projects.

Closes #333.