### PR TITLE
Fix `Tabs` border color

### DIFF
--- a/src/lib/components/Tabs/TabsItem.scss
+++ b/src/lib/components/Tabs/TabsItem.scss
@@ -47,8 +47,7 @@
     line-height: 1;
     text-decoration: none;
     color: theme.$item-color;
-    border-width: theme.$item-border-width;
-    border-style: solid;
+    border: theme.$item-border-width solid;
     border-color: theme.$item-border-color;
     border-top-left-radius: theme.$item-border-radius;
     border-top-right-radius: theme.$item-border-radius;


### PR DESCRIPTION
Item border color disappeared during CSS minification:

A shorthand for `border` was generated which made the final rule with four colors invalid.

Before:

<img width="839" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/177776849-c5725d4e-ca49-4c09-8ee6-7e8a93f507e8.png">

After:

<img width="841" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/177776797-d76833a9-daf7-43a8-ab8d-28980fd3151c.png">
