### PR TITLE
Redesign `Modal` introducing `ModalTitle` and new theming options (#306)

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -127,6 +127,28 @@ export default {
     showPlaygroundEditor: false,
     styles: {
       Container: {
+        '& > div > div > div > :is(ul, ol)': {
+          ml: 5,
+        },
+        '& > div > div > div > h1': {
+          fontFamily: defaultFontFamily,
+          mb: 4,
+        },
+        '& > div > div > div > h2': {
+          fontSize: 5,
+          mb: 3,
+          mt: 5,
+        },
+        '& > div > div > div > h3': {
+          fontSize: 4,
+          mb: 2,
+          mt: 4,
+        },
+        '& > div > div > div > h4': {
+          fontSize: 3,
+          mb: 1,
+          mt: 2,
+        },
         '& [data-testid="live-preview"]': {
           fontSize: '1rem', // Set the font size in playground to override the docs theme default.
           overflow: 'auto', // Make preview scrollable.
@@ -153,10 +175,6 @@ export default {
           maxHeight: codeMaxHeight,
           overflow: 'auto !important',
         },
-        '& [data-testid="playground"] h3': { // Fix headings in modals.
-          fontSize: 'var(--rui-typography-size-1)',
-          m: 0,
-        },
         '& [data-testid="playground"] pre': {
           maxHeight: 'none',
         },
@@ -175,35 +193,13 @@ export default {
         'code, pre': {
           fontSize: '80%', // Adjust code font size to work better with 20px body text size.
         },
-        h1: {
-          fontFamily: defaultFontFamily,
-          mb: 4,
-        },
         'h1 + p': {
           fontSize: 4,
-        },
-        h2: {
-          fontSize: 5,
-          mb: 3,
-          mt: 5,
-        },
-        h3: {
-          fontSize: 4,
-          mb: 2,
-          mt: 4,
-        },
-        h4: {
-          fontSize: 3,
-          mb: 1,
-          mt: 2,
         },
         hr: {
           my: 6,
         },
         maxWidth: 1150,
-        ol: {
-          ml: 5,
-        },
         p: null,
         pre: {
           maxHeight: codeMaxHeight,
@@ -228,9 +224,6 @@ export default {
         },
         'table ul, table ol': {
           ml: 1,
-        },
-        ul: {
-          ml: 5,
         },
       },
       Header: {

--- a/src/lib/components/Modal/Modal.scss
+++ b/src/lib/components/Modal/Modal.scss
@@ -18,6 +18,7 @@
     max-width: calc(100% - (2 * var(--rui-local-outer-spacing)));
     max-height: calc(100% - (2 * var(--rui-local-outer-spacing)));
     overflow-y: auto;
+    overscroll-behavior: contain;
     border-radius: settings.$border-radius;
     background: theme.$background;
     box-shadow: theme.$box-shadow;

--- a/src/lib/components/Modal/ModalBody.jsx
+++ b/src/lib/components/Modal/ModalBody.jsx
@@ -3,12 +3,13 @@ import React from 'react';
 import { withGlobalProps } from '../../provider';
 import { classNames } from '../../utils/classNames';
 import { isChildrenEmpty } from '../_helpers/isChildrenEmpty';
+import { getScrollingClassName } from './_helpers/getScrollingClassName';
 import styles from './ModalBody.scss';
 
 export const ModalBody = ({
   children,
   id,
-  withScrollView,
+  scrolling,
 }) => {
   if (isChildrenEmpty(children)) {
     return null;
@@ -18,7 +19,7 @@ export const ModalBody = ({
     <div
       className={classNames(
         styles.root,
-        withScrollView && styles.isRootScrollable,
+        getScrollingClassName(scrolling, styles),
       )}
       id={id}
     >
@@ -30,7 +31,7 @@ export const ModalBody = ({
 ModalBody.defaultProps = {
   children: null,
   id: undefined,
-  withScrollView: false,
+  scrolling: 'auto',
 };
 
 ModalBody.propTypes = {
@@ -38,8 +39,9 @@ ModalBody.propTypes = {
    * Nested elements. Supported types are:
    *
    * * `ModalContent`
-   * * `ScrollView` (`withScrollView: true` must be set)
+   * * `ScrollView` (`scrolling: 'custom'` must be set)
    *
+   * You can also provide a custom component responsible for scrolling and displaying content correctly.
    * At most one nested element is allowed. If none are provided nothing is rendered.
    */
   children: PropTypes.node,
@@ -48,9 +50,13 @@ ModalBody.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * If `true`, body is scroll-compatible and its child must be instance of `ScrollView`.
+   * Scrolling mode:
+   *
+   * - `auto`: scrolling is enabled on ModalBody.
+   * - `custom`: use if providing a custom scrolling component, e.g. an instance of `ScrollView`.
+   * - `none`: scrolling is disabled on ModalBody and the entire Modal is scrollable instead.
    */
-  withScrollView: PropTypes.bool,
+  scrolling: PropTypes.oneOf(['auto', 'custom', 'none']),
 };
 
 export const ModalBodyWithGlobalProps = withGlobalProps(ModalBody, 'ModalBody');

--- a/src/lib/components/Modal/ModalBody.scss
+++ b/src/lib/components/Modal/ModalBody.scss
@@ -1,15 +1,18 @@
-@use "settings";
-
 .root {
     flex: 1 1 auto;
 }
 
-.isRootScrollable {
-    display: flex;
-    flex-direction: column;
+.isRootScrollingAuto,
+.isRootScrollingCustom {
     min-height: 0;
 }
 
-.root:first-child:not(.isRootScrollable) {
-    padding-top: settings.$padding-y;
+.isRootScrollingAuto {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.isRootScrollingCustom {
+    display: flex;
+    flex-direction: column;
 }

--- a/src/lib/components/Modal/ModalContent.scss
+++ b/src/lib/components/Modal/ModalContent.scss
@@ -1,5 +1,5 @@
-@use "settings";
+@use "theme";
 
 .root {
-    padding: settings.$padding-y settings.$padding-x settings.$content-padding-bottom;
+    padding: theme.$padding-y theme.$padding-x;
 }

--- a/src/lib/components/Modal/ModalFooter.scss
+++ b/src/lib/components/Modal/ModalFooter.scss
@@ -7,7 +7,8 @@
     flex-wrap: wrap;
     gap: theme.$footer-gap;
     align-items: center;
-    padding: settings.$padding-y settings.$padding-x;
+    padding: theme.$padding-y theme.$padding-x;
+    border-top: theme.$separator-width solid theme.$separator-color;
     border-bottom-right-radius: settings.$border-radius;
     border-bottom-left-radius: settings.$border-radius;
     background: theme.$footer-background;

--- a/src/lib/components/Modal/ModalHead.jsx
+++ b/src/lib/components/Modal/ModalHead.jsx
@@ -43,7 +43,7 @@ ModalHead.defaultProps = {
 
 ModalHead.propTypes = {
   /**
-   * Content of the head (preferably heading element with ModalCloseButton element).
+   * Content of the header (preferably ModalTitle and ModalCloseButton).
    */
   children: PropTypes.node.isRequired,
   /**

--- a/src/lib/components/Modal/ModalHead.scss
+++ b/src/lib/components/Modal/ModalHead.scss
@@ -1,6 +1,3 @@
-@use "sass:map";
-@use "../../styles/tools/spacing";
-@use "settings";
 @use "theme";
 
 .root {
@@ -10,20 +7,6 @@
     align-items: baseline;
     padding: theme.$padding-y theme.$padding-x;
     border-bottom: theme.$separator-width solid theme.$separator-color;
-}
-
-.root h1,
-.root h2,
-.root h3,
-.root h4,
-.root h5,
-.root h6 {
-    /* stylelint-disable declaration-no-important */
-    // TODO: Solve this !!!!!!
-    margin-top: 0 !important;
-    margin-bottom: 0 !important;
-    font-size: settings.$head-title-font-size !important;
-    /* stylelint-enable declaration-no-important */
 }
 
 .isJustifiedToCenter {

--- a/src/lib/components/Modal/ModalHead.scss
+++ b/src/lib/components/Modal/ModalHead.scss
@@ -8,7 +8,8 @@
     flex: none;
     gap: theme.$head-gap;
     align-items: baseline;
-    padding: settings.$padding-y spacing.of(4) settings.$padding-y settings.$padding-x;
+    padding: theme.$padding-y theme.$padding-x;
+    border-bottom: theme.$separator-width solid theme.$separator-color;
 }
 
 .root h1,

--- a/src/lib/components/Modal/ModalTitle.jsx
+++ b/src/lib/components/Modal/ModalTitle.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+  withGlobalProps,
+} from '../../provider';
+import styles from './ModalTitle.scss';
+
+export const ModalTitle = ({
+  children,
+  id,
+  level,
+}) => {
+  const HeadingTag = `h${level}`;
+
+  return (
+    <HeadingTag className={styles.root} id={id}>
+      {children}
+    </HeadingTag>
+  );
+};
+
+ModalTitle.defaultProps = {
+  id: undefined,
+  level: 2,
+};
+
+ModalTitle.propTypes = {
+  /**
+   * Content of the header (preferably ModalTitle and ModalCloseButton).
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * ID of the root HTML element.
+   */
+  id: PropTypes.string,
+  /**
+   * Optional heading level. Preferably `1` or `2` should be used, see
+   * [W3C recommendation](https://github.com/w3c/aria-practices/issues/551#issuecomment-365134527).
+   */
+  level: PropTypes.number,
+};
+
+export const ModalTitleWithGlobalProps = withGlobalProps(ModalTitle, 'ModalTitle');
+
+export default ModalTitleWithGlobalProps;

--- a/src/lib/components/Modal/ModalTitle.scss
+++ b/src/lib/components/Modal/ModalTitle.scss
@@ -1,0 +1,10 @@
+@use "settings";
+
+.root {
+    margin-block: 0;
+    font-size: settings.$title-font-size;
+
+    &:not(:last-child) {
+        margin-bottom: 0;
+    }
+}

--- a/src/lib/components/Modal/README.mdx
+++ b/src/lib/components/Modal/README.mdx
@@ -984,8 +984,12 @@ opened.
 
 | Custom Property                                      | Description                                                  |
 |------------------------------------------------------|--------------------------------------------------------------|
+| `--rui-Modal__padding-x`                             | Inline padding of individual modal components                |
+| `--rui-Modal__padding-y`                             | Block padding of individual modal components                 |
 | `--rui-Modal__background`                            | Modal background (including `url()` or gradient)             |
 | `--rui-Modal__box-shadow`                            | Modal box shadow                                             |
+| `--rui-Modal__separator__width`                      | Width of separator between modal head, body, and footer      |
+| `--rui-Modal__separator__color`                      | Color of separator between modal head, body, and footer      |
 | `--rui-Modal__head__gap`                             | Modal head gap between children                              |
 | `--rui-Modal__outer-spacing-xs`                      | Spacing around modal, `xs` screen size                       |
 | `--rui-Modal__outer-spacing-sm`                      | Spacing around modal, `sm` screen size and bigger            |

--- a/src/lib/components/Modal/README.mdx
+++ b/src/lib/components/Modal/README.mdx
@@ -21,6 +21,7 @@ import {
   ModalContent,
   ModalFooter,
   ModalHead,
+  ModalTitle,
   ScrollView,
   TextField,
   Toolbar,
@@ -41,6 +42,7 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
+  ModalTitle,
 } from '@react-ui-org/react-ui';
 ```
 
@@ -65,7 +67,7 @@ And use it:
               primaryButtonRef={modalPrimaryButtonRef}
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <ModalTitle>Delete the user?</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -127,6 +129,7 @@ Modal is decomposed into the following components:
 
 - [Modal](#api)
   - [ModalHead](#modalhead-1)
+    - [ModalTitle](#modaltitle)
     - [ModalCloseButton](#modalclosebutton)
   - [ModalBody](#modalbody-1)
     - [ModalContent](#modalcontent)
@@ -187,7 +190,7 @@ e.g. dialog modal, blocking modal, scrollable modal, etc.
           {modalOpen === 2 && (
             <Modal>
               <ModalHead>
-                <h2>Action finished</h2>
+                <ModalTitle>Action finished</ModalTitle>
               </ModalHead>
               <ModalBody>
                 <ModalContent>
@@ -205,7 +208,7 @@ e.g. dialog modal, blocking modal, scrollable modal, etc.
               primaryButtonRef={modalPrimaryButtonRef}
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <ModalTitle>Delete the user?</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -238,7 +241,7 @@ e.g. dialog modal, blocking modal, scrollable modal, etc.
               primaryButtonRef={modalPrimaryButtonRef}
             >
               <ModalHead>
-                <h2>Add new user</h2>
+                <ModalTitle>Add new user</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -276,9 +279,8 @@ ModalHead is an optional part of the Modal which allows you to display the title
 of the modal and its close button.
 
 It is recommended to compose ModalHead from the following elements. For title,
-use heading element `h1` or `h2` (see [W3C recommendation][w3c-dialog-heading]).
-For the close button, use ModalCloseButton, whereas it could be omitted if the
-close button is a part of ModalFooter.
+use ModalTitle. For the close button, use ModalCloseButton, however it can
+be omitted if a close button is part of ModalFooter.
 
 There are two ways how to position elements within the ModalHead:
 
@@ -314,7 +316,7 @@ There are two ways how to position elements within the ModalHead:
           priority="outline"
         />
         <Button
-          label="Launch without close button and centered title"
+          label="Launch without close button and with centered title"
           onClick={() => {
             setModalOpen(true);
             setVariant(3);
@@ -337,18 +339,18 @@ There are two ways how to position elements within the ModalHead:
             >
               {variant === 1 && (
                 <ModalHead>
-                  <h2>Delete the user?</h2>
+                  <ModalTitle>Delete the user?</ModalTitle>
                   <ModalCloseButton onClick={() => setModalOpen(false)} />
                 </ModalHead>
               )}
               {variant === 2 && (
                 <ModalHead>
-                  <h2>Delete the user?</h2>
+                  <ModalTitle>Delete the user?</ModalTitle>
                 </ModalHead>
               )}
               {variant === 3 && (
                 <ModalHead justify="center">
-                  <h2>Delete the user?</h2>
+                  <ModalTitle>Delete the user?</ModalTitle>
                 </ModalHead>
               )}
               {variant === 4 && (
@@ -358,7 +360,7 @@ There are two ways how to position elements within the ModalHead:
                       {''}
                     </ToolbarItem>
                     <ToolbarItem>
-                      <h2>Delete the user?</h2>
+                      <ModalTitle>Delete the user?</ModalTitle>
                     </ToolbarItem>
                     <ToolbarItem>
                       <ModalCloseButton onClick={() => setModalOpen(false)} />
@@ -476,7 +478,7 @@ There are two ways to position buttons within the ModalFooter:
               primaryButtonRef={modalPrimaryButtonRef}
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <ModalTitle>Delete the user?</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -598,7 +600,7 @@ Modals of any size automatically shrink when they cannot fit the screen width.
               size={modalSize}
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <ModalTitle>Delete the user?</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -658,7 +660,7 @@ magic that doesn't work together yet 🎩.
               size="auto"
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <ModalTitle>Delete the user?</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -727,7 +729,7 @@ Modal can be aligned either to the top or center of the screen.
               primaryButtonRef={modalPrimaryButtonRef}
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <ModalTitle>Delete the user?</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody>
@@ -913,7 +915,7 @@ independent of the page itself. This can be done in three ways using the
               size="small"
             >
               <ModalHead>
-                <h2>Modal with long content</h2>
+                <ModalTitle>Modal with long content</ModalTitle>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
               <ModalBody scrolling={modalScrolling}>
@@ -964,6 +966,10 @@ opened.
 
 <Props table of={ModalHead} />
 
+### ModalTitle
+
+<Props table of={ModalTitle} />
+
 ### ModalCloseButton
 
 <Props table of={ModalCloseButton} />
@@ -1003,5 +1009,3 @@ opened.
 | `--rui-Modal--large__width`                          | Width of large modal                                         |
 | `--rui-Modal--fullscreen__width`                     | Width of fullscreen modal                                    |
 | `--rui-Modal--fullscreen__height`                    | Height of fullscreen modal                                   |
-
-[w3c-dialog-heading]: https://github.com/w3c/aria-practices/issues/551#issuecomment-365134527

--- a/src/lib/components/Modal/README.mdx
+++ b/src/lib/components/Modal/README.mdx
@@ -788,15 +788,20 @@ elements manually, set the `autoFocus` prop on Modal to `false`.
 
 ## Scrolling Long Content
 
-When modals become too long for the user's viewport or device, we recommend
-wrapping ModalContent into [ScrollView](/components/scroll-view) to make the
-content scrollable independently of the page itself. In this case,
-`withScrollView` must be set to `true` on ModalBody.
+When modals become too long for the user's viewport or device, they scroll
+independent of the page itself. This can be done in three ways using the
+`scrolling` option of the ModalBody component:
+
+- `auto` (default) — ModalBody is responsible for scrolling,
+- `custom` — you must provide a custom component to handle scrolling,
+   typically an instance of [ScrollView](/components/scroll-view) wrapping
+   ModalContent,
+- `none` — entire Modal is responsible for scrolling.
 
 <Playground>
   {() => {
     const [modalOpen, setModalOpen] = React.useState(false);
-    const [modalScrollView, setModalScrollView] = React.useState(true);
+    const [modalScrolling, setModalScrolling] = React.useState('auto');
     const modalCloseButtonRef = React.useRef();
     const modalPrimaryButtonRef = React.useRef();
     const modalContent = (
@@ -878,15 +883,23 @@ content scrollable independently of the page itself. In this case,
         <Button
           label="Launch modal with scrolling body"
           onClick={() => {
-            setModalScrollView(true);
+            setModalScrolling('auto');
             setModalOpen(true);
           }}
           priority="outline"
         />
         <Button
-          label="Launch scrolling modal"
+          label="Launch modal with ScrollView"
           onClick={() => {
-            setModalScrollView(false);
+            setModalScrolling('custom');
+            setModalOpen(true);
+          }}
+          priority="outline"
+        />
+        <Button
+          label="Launch modal with non-scrolling body"
+          onClick={() => {
+            setModalScrolling('none');
             setModalOpen(true);
           }}
           priority="outline"
@@ -898,15 +911,14 @@ content scrollable independently of the page itself. In this case,
               closeButtonRef={modalCloseButtonRef}
               primaryButtonRef={modalPrimaryButtonRef}
               size="small"
-              title="Modal with long content"
             >
               <ModalHead>
-                <h2>Delete the user?</h2>
+                <h2>Modal with long content</h2>
                 <ModalCloseButton onClick={() => setModalOpen(false)} />
               </ModalHead>
-              <ModalBody withScrollView={modalScrollView}>
+              <ModalBody scrolling={modalScrolling}>
                 {
-                  modalScrollView
+                  modalScrolling === 'custom'
                     ? (
                       <ScrollView>
                         {modalContent}

--- a/src/lib/components/Modal/__tests__/ModalBody.test.jsx
+++ b/src/lib/components/Modal/__tests__/ModalBody.test.jsx
@@ -28,10 +28,27 @@ describe('rendering', () => {
     ...idPropTest,
     [
       {
-        withScrollView: true,
+        scrolling: 'auto',
       },
       (rootElement) => {
-        expect(rootElement).toHaveClass('isRootScrollable');
+        expect(rootElement).toHaveClass('isRootScrollingAuto');
+      },
+    ],
+    [
+      {
+        scrolling: 'custom',
+      },
+      (rootElement) => {
+        expect(rootElement).toHaveClass('isRootScrollingCustom');
+      },
+    ],
+    [
+      {
+        scrolling: 'none',
+      },
+      (rootElement) => {
+        expect(rootElement).not.toHaveClass('isRootScrollingAuto');
+        expect(rootElement).not.toHaveClass('isRootScrollingCustom');
       },
     ],
   ])('renders with props: "%s"', (testedProps, assert) => {

--- a/src/lib/components/Modal/__tests__/ModalTitle.test.jsx
+++ b/src/lib/components/Modal/__tests__/ModalTitle.test.jsx
@@ -3,7 +3,7 @@ import {
   render,
   within,
 } from '@testing-library/react';
-import { ModalContent } from '../ModalContent';
+import { ModalTitle } from '../ModalTitle';
 import { idPropTest } from '../../../../../tests/propTests/idPropTest';
 
 const mandatoryProps = {
@@ -27,9 +27,17 @@ describe('rendering', () => {
       },
     ],
     ...idPropTest,
+    [
+      {
+        level: 1,
+      },
+      (rootElement) => {
+        expect(rootElement).toContainHTML('<h1');
+      },
+    ],
   ])('renders with props: "%s"', (testedProps, assert) => {
     const dom = render((
-      <ModalContent
+      <ModalTitle
         {...mandatoryProps}
         {...testedProps}
       />

--- a/src/lib/components/Modal/_helpers/getScrollingClassName.js
+++ b/src/lib/components/Modal/_helpers/getScrollingClassName.js
@@ -1,0 +1,11 @@
+export const getScrollingClassName = (type, styles) => {
+  if (type === 'auto') {
+    return styles.isRootScrollingAuto;
+  }
+
+  if (type === 'custom') {
+    return styles.isRootScrollingCustom;
+  }
+
+  return null;
+};

--- a/src/lib/components/Modal/_settings.scss
+++ b/src/lib/components/Modal/_settings.scss
@@ -4,8 +4,6 @@
 @use "../../styles/theme/typography";
 @use "../../styles/tools/spacing";
 
-$padding-x: spacing.of(5);
-$padding-y: spacing.of(3);
 $content-padding-bottom: spacing.of(6);
 $border-radius: borders.$radius;
 $head-title-font-size: map.get(typography.$size-values, 1);

--- a/src/lib/components/Modal/_settings.scss
+++ b/src/lib/components/Modal/_settings.scss
@@ -2,10 +2,8 @@
 @use "../../styles/settings/z-indexes";
 @use "../../styles/theme/borders";
 @use "../../styles/theme/typography";
-@use "../../styles/tools/spacing";
 
-$content-padding-bottom: spacing.of(6);
 $border-radius: borders.$radius;
-$head-title-font-size: map.get(typography.$size-values, 1);
 $z-index: z-indexes.$modal;
 $backdrop-z-index: z-indexes.$modal-backdrop;
+$title-font-size: map.get(typography.$size-values, 1);

--- a/src/lib/components/Modal/_theme.scss
+++ b/src/lib/components/Modal/_theme.scss
@@ -1,5 +1,9 @@
+$padding-x: var(--rui-Modal__padding-x);
+$padding-y: var(--rui-Modal__padding-y);
 $background: var(--rui-Modal__background);
 $box-shadow: var(--rui-Modal__box-shadow);
+$separator-width: var(--rui-Modal__separator__width);
+$separator-color: var(--rui-Modal__separator__color);
 $head-gap: var(--rui-Modal__head__gap);
 $footer-background: var(--rui-Modal__footer__background);
 $footer-gap: var(--rui-Modal__footer__gap);

--- a/src/lib/components/Modal/index.js
+++ b/src/lib/components/Modal/index.js
@@ -4,3 +4,4 @@ export { default as ModalCloseButton } from './ModalCloseButton';
 export { default as ModalContent } from './ModalContent';
 export { default as ModalHead } from './ModalHead';
 export { default as ModalFooter } from './ModalFooter';
+export { default as ModalTitle } from './ModalTitle';

--- a/src/lib/components/ScrollView/ScrollView.scss
+++ b/src/lib/components/ScrollView/ScrollView.scss
@@ -75,7 +75,6 @@ $_arrow-outer-spacing: spacing.of(4);
     z-index: 1; // 2.
     width: 100%;
     scroll-behavior: smooth;
-    -webkit-overflow-scrolling: touch;
 }
 
 .arrowPrev,

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -34,6 +34,7 @@ export {
   ModalContent,
   ModalFooter,
   ModalHead,
+  ModalTitle,
 } from './components/Modal';
 export { default as Paper } from './components/Paper';
 export { default as Radio } from './components/Radio';

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -875,8 +875,12 @@
     // Modal
     // =====
 
+    --rui-Modal__padding-x: var(--rui-spacing-4);
+    --rui-Modal__padding-y: var(--rui-spacing-4);
     --rui-Modal__background: var(--rui-color-white);
     --rui-Modal__box-shadow: none;
+    --rui-Modal__separator__width: var(--rui-border-width);
+    --rui-Modal__separator__color: var(--rui-color-gray-100);
     --rui-Modal__head__gap: var(--rui-spacing-2);
     --rui-Modal__outer-spacing--xs: var(--rui-spacing-2);
     --rui-Modal__outer-spacing--sm: var(--rui-spacing-6);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,8 @@ const path = require('path');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const VisualizerPlugin = require('webpack-visualizer-plugin');
 
-const MAX_DEVELOPMENT_OUTPUT_SIZE = 2800000;
-const MAX_PRODUCTION_OUTPUT_SIZE = 320000;
+const MAX_DEVELOPMENT_OUTPUT_SIZE = 2900000;
+const MAX_PRODUCTION_OUTPUT_SIZE = 330000;
 
 module.exports = (env, argv) => ({
   devtool: argv.mode === 'production'


### PR DESCRIPTION
## Changes

- Enhance `Modal` scrolling modes
- Redesign `Modal` introducing new theming options
- Introduce `ModalTitle` component to better handle default modal title styling

Relates to issue #306 and PR #387.

## New default design

<img width="702" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/178560712-5064a854-f38e-42de-977d-8f2114a6f021.png">

## New custom properties

- `--rui-Modal__padding-x`
- `--rui-Modal__padding-y`
- `--rui-Modal__separator__width`
- `--rui-Modal__separator__color`