### PR TITLE
Rewrite `ScrollView` API to limit the number of customization approaches (#303)

### DIFF
--- a/src/lib/components/ScrollView/README.mdx
+++ b/src/lib/components/ScrollView/README.mdx
@@ -9,7 +9,7 @@ route: /components/scroll-view
 ScrollView makes long content scrollable.
 
 👉 Please note that HTML is rendered even when no children are provided.
-This is needed to allow the autoscroll feature to work.
+This is needed to allow the auto-scroll feature to work.
 
 import {
   Playground,
@@ -89,9 +89,9 @@ See [API](#api) for all available options.
   to restrict the height of its parent to activate scrolling.
 
 - While arrow controls are optional in the vertical mode, you should always
-  **enable arrows in the horizontal mode when scrollbar is disabled.** Because
-  if you don't, users without horizontal-scrolling-enabled devices (like an
-  old-school mouse) might not be able to access your content.
+  **enable arrows in the horizontal mode when the scrollbar is disabled.**
+  Because if you don't, users without horizontal-scrolling-enabled devices
+  (like an old-school mouse) might not be able to access your content.
 
 - For dynamic content such as chat window or console output, consider using the
   **auto-scroll feature**. This will ensure the newest content is always
@@ -101,13 +101,13 @@ See [API](#api) for all available options.
   area in your app scrollable based on viewport size, please use custom CSS
   with media queries instead.
 
-- ScrollView only supports **scrolling in single direction at a time.** It crops
-  content that could possibly overflow in the other direction because additional
-  scrollbars would be unreachable under scrolling shadows. If you need your
-  content to be ready for bi-directional scrolling, either consider using just
-  `overflow: auto` instead of ScrollView, or make your content scrollable before
-  putting it into ScrollView and make sure its scrollbars don't collide with
-  scrolling shadows.
+- ScrollView only supports **scrolling in a single direction at a time.** It
+  crops content that would possibly overflow in the other direction because
+  additional scrollbars would be unreachable under scrolling shadows. If you
+  need your content to be ready for bi-directional scrolling, either consider
+  using just `overflow: auto` instead of ScrollView, or make your content
+  scrollable before putting it into ScrollView and make sure its scrollbars
+  don't collide with scrolling shadows.
 
 ## Arrows
 
@@ -168,7 +168,7 @@ horizontal content and you need to make sure it remains accessible on all
 viewport sizes.
 
 <Playground>
-  <ScrollView direction="horizontal">
+  <ScrollView direction="horizontal" arrows>
     <Placeholder>
       <div style={{ whiteSpace: 'nowrap' }}>
         Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
@@ -284,60 +284,20 @@ property defined because it detects changes of these keys.
 It's possible to entirely customize the arrow controls, including the scroll
 step, and the scrolling shadows.
 
-### Custom Arrows and Shadow Color
+### Custom Arrows
 
-You can pass any HTML element or even custom React component to be used as the
-arrow control.
-
-The color of arrows and scrolling shadows can be simply adjusted, too. While the
-`arrowsColor` accepts
-[color in any valid CSS format](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value),
-the `shadowColor` is broken down to individual color channels so we can easily
-derive the transparent version from the value without having to parse it.
-
-Furthermore, you can change the scroll step if you need to scroll by smaller or
-bigger portions.
+You can pass any HTML element or even a custom React component to be used as the
+arrow control. Furthermore, you can change the scroll step if you need to scroll
+by smaller or bigger portions.
 
 <Playground>
   <ScrollView
     arrows
-    arrowsColor="white"
     arrowsScrollStep={300}
-    customNextArrow={(
-      <span
-        style={{
-          fontSize: '1.5rem',
-          fontWeight: 'bold',
-          position: 'relative',
-          textShadow: '0 0 0.4em black',
-          top: '-0.05em',
-        }}
-      >
-        →
-      </span>
-    )}
-    customPrevArrow={(
-      <span
-        style={{
-          fontSize: '1.5rem',
-          fontWeight: 'bold',
-          position: 'relative',
-          textShadow: '0 0 0.4em black',
-          top: '-0.05em',
-        }}
-      >
-        ←
-      </span>
-    )}
     direction="horizontal"
+    nextArrowElement={(<span class="typography-size-3">➡️</span>)}
+    prevArrowElement={(<span class="typography-size-3">⬅️</span>)}
     scrollbar={false}
-    shadowColor={{
-      alpha: 0.75,
-      blue: 0,
-      green: 0,
-      red: 0,
-    }}
-    shadowSize="5rem"
   >
     <Placeholder>
       <div style={{ whiteSpace: 'nowrap' }}>
@@ -352,33 +312,34 @@ bigger portions.
   </ScrollView>
 </Playground>
 
-### Custom Scrolling Shadows
+### Scrolling Shadows
 
-Aside from setting a custom shadow color and size, you can entirely customize
-the scrolling shadows with `background` or `box-shadow` CSS properties.
+You can customize the start and end scrolling shadows using `startShadow*` and
+`endShadow*` properties.
 
 <Playground>
   <Placeholder height="200px">
     <ScrollView
-      customStartShadowStyle={{
-        background: 'radial-gradient('
+      startShadowBackground={'radial-gradient('
           + 'farthest-side at center top, '
           + 'rgba(0, 0, 0, 0.15) 0%, '
           + 'rgba(0, 0, 0, 0.05) 60%, '
           + 'rgba(0, 0, 0, 0.02) 85%, '
           + 'rgba(0, 0, 0, 0) 100%'
-        + ')',
-      }}
-      customEndShadowStyle={{
-        background: 'radial-gradient('
+        + ')'
+      }
+      startShadowInitialOffset="-5px"
+      startShadowSize="40px"
+      endShadowBackground={'radial-gradient('
           + 'farthest-side at center bottom, '
           + 'rgba(0, 0, 0, 0.15) 0%, '
           + 'rgba(0, 0, 0, 0.05) 60%, '
           + 'rgba(0, 0, 0, 0.02) 85%, '
           + 'rgba(0, 0, 0, 0) 100%'
-        + ')',
-      }}
-      shadowSize="40px"
+        + ')'
+      }
+      endShadowInitialOffset="-5px"
+      endShadowSize="40px"
     >
       <div>
         Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
@@ -425,13 +386,115 @@ the scrolling shadows with `background` or `box-shadow` CSS properties.
   </Placeholder>
 </Playground>
 
+#### Linear Gradients
+
+For easier CSS definition of [linear gradients] for both vertical and horizontal
+directions at the same time, there are `--rui-local-start-shadow-direction` and
+`--rui-local-end-shadow-direction` custom properties that can be used inside
+`startShadowBackground` and `endShadowBackground` definitions. The value of the
+custom properties then reacts to the `direction` option:
+
+| Custom property                      | Vertical direction | Horizontal direction |
+|--------------------------------------|--------------------|----------------------|
+| `--rui-local-start-shadow-direction` | `to bottom`        | `to right`           |
+| `--rui-local-end-shadow-direction`   | `to top`           | `to left`            |
+
+This is useful if you want to create a single definition of linear gradients for
+scrolling shadows in both directions via
+[global props](/customize/global-props).
+
+<Playground>
+  {() => {
+    const START_SHADOW_BACKGROUND = `linear-gradient(
+        var(--rui-local-start-shadow-direction),
+        rgba(0 0 0 / 0.5),
+        rgba(0 0 0 / 0)
+      )`;
+    const END_SHADOW_BACKGROUND = `linear-gradient(
+        var(--rui-local-end-shadow-direction),
+        rgba(0 0 0 / 0.5),
+        rgba(0 0 0 / 0)
+      )`
+    const [direction, setDirection] = React.useState('vertical');
+    return(
+      <>
+        <Radio
+          label="Direction:"
+          onChange={(e) => setDirection(e.target.value)}
+          options={[
+            {
+              label: 'Vertical',
+              value: 'vertical',
+            },
+            {
+              label: 'Horizontal',
+              value: 'horizontal',
+            },
+          ]}
+          value={direction}
+        />
+        <Placeholder height="200px">
+          <ScrollView
+            direction={direction}
+            endShadowBackground={END_SHADOW_BACKGROUND}
+            startShadowBackground={START_SHADOW_BACKGROUND}
+          >
+            <div
+              style={{
+                width: (direction === 'horizontal' ? '3000px' : 'auto'),
+              }}
+            >
+              Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+              commodo ligula eget dolor. Aenean massa. Cum sociis natoque
+              penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+              Donec quam felis, ultricies nec, pellentesque eu, pretium quis,
+              sem. Nulla consequat massa quis enim. Donec pede justo, fringilla
+              vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut,
+              imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede
+              mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum
+              semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula,
+              porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem
+              ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus
+              viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean
+              imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper
+              ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
+              tellus eget condimentum rhoncus, sem quam semper libero, sit amet
+              adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus
+              pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt
+              tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam
+              quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis
+              leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis
+              magna. Sed consequat, leo eget bibendum sodales, augue velit
+              cursus nunc. Aenean massa. Cum sociis natoque penatibus et magnis
+              dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+              ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat
+              massa quis enim. Donec pede justo, fringilla vel, aliquet nec,
+              vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a,
+              venenatis vitae, justo. Nullam dictum felis eu pede mollis
+              pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper
+              nisi. Aenean vulputate eleifend tellus. Aenean leo ligula,
+              porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem
+              ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus
+              viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean
+              imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper
+              ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
+              tellus eget condimentum rhoncus, sem quam semper libero, sit amet
+              adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus
+              pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt
+              tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam
+              quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis
+              leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis
+              magna. Sed consequat, leo eget bibendum sodales, augue velit
+              cursus nunc.
+            </div>
+          </ScrollView>
+        </Placeholder>
+      </>
+    )}}
+</Playground>
+
 ## API
 
 <Props table of={ScrollView} />
 
-## Theming
-
-| Custom Property                                      | Description                                                  |
-|------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-ScrollView__arrow__initial-offset`            | Initial offset of scrolling arrows (transitioned)            |
-| `--rui-ScrollView__shadow__initial-offset`           | Initial offset of scrolling shadows (transitioned)           |
+[linear gradients]: https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient

--- a/src/lib/components/ScrollView/ScrollView.scss
+++ b/src/lib/components/ScrollView/ScrollView.scss
@@ -1,7 +1,7 @@
 // 1. Scrolling shadows are implemented as pseudo elements. This way we can customise them only
 //    with custom properties.
 //
-// 2. Stack scrolling shadows  over viewport content while keeping the content interactive.
+// 2. Stack scrolling shadows over viewport content while keeping the content interactive.
 //
 //    - `.scrollingShadows` is positioned absolutely over the `.root`, with auto `z-index` (this is
 //      important!), and with `overflow: hidden` to clip the shadows (ie. its pseudo elements).
@@ -27,7 +27,6 @@
 @use "../../styles/tools/scrollbar";
 @use "../../styles/tools/spacing";
 @use "../../styles/tools/transition";
-@use "theme";
 
 $_arrow-inner-spacing: spacing.of(2);
 $_arrow-outer-spacing: spacing.of(4);
@@ -45,6 +44,7 @@ $_arrow-outer-spacing: spacing.of(4);
     width: 100%; // 2.
     height: 100%; // 2.
     overflow: hidden; // 2.
+    pointer-events: none; // 2.
 
     &::before,
     &::after {
@@ -54,20 +54,16 @@ $_arrow-outer-spacing: spacing.of(4);
         position: absolute;
         z-index: 2; // 2.
         display: block;
-        width: var(--rui-local-shadow-width);
-        height: var(--rui-local-shadow-height);
         visibility: hidden;
         opacity: 0;
     }
 
     &::before {
         background: var(--rui-local-start-shadow-background);
-        box-shadow: var(--rui-local-start-shadow-box-shadow);
     }
 
     &::after {
         background: var(--rui-local-end-shadow-background);
-        box-shadow: var(--rui-local-end-shadow-box-shadow);
     }
 }
 
@@ -88,7 +84,6 @@ $_arrow-outer-spacing: spacing.of(4);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--rui-local-arrow-color);
     visibility: hidden;
     opacity: 0;
 }
@@ -115,7 +110,8 @@ $_arrow-outer-spacing: spacing.of(4);
     width: 100%;
     padding-top: $_arrow-outer-spacing;
     padding-bottom: $_arrow-inner-spacing;
-    transform: translateY(theme.$arrow-initial-offset);
+    color: var(--rui-local-prev-arrow-color);
+    transform: translateY(var(--rui-local-prev-arrow-initial-offset));
 }
 
 .isRootVertical .arrowPrev .arrowIcon {
@@ -129,7 +125,8 @@ $_arrow-outer-spacing: spacing.of(4);
     width: 100%;
     padding-top: $_arrow-inner-spacing;
     padding-bottom: $_arrow-outer-spacing;
-    transform: translateY(calc(-1 * #{theme.$arrow-initial-offset}));
+    color: var(--rui-local-next-arrow-color);
+    transform: translateY(calc(-1 * var(--rui-local-next-arrow-initial-offset)));
 }
 
 .isRootHorizontal {
@@ -142,7 +139,7 @@ $_arrow-outer-spacing: spacing.of(4);
     left: 0;
     padding-right: $_arrow-inner-spacing;
     padding-left: $_arrow-outer-spacing;
-    transform: translateX(theme.$arrow-initial-offset);
+    transform: translateX(var(--rui-local-prev-arrow-initial-offset));
 }
 
 .isRootHorizontal .arrowPrev .arrowIcon {
@@ -155,7 +152,7 @@ $_arrow-outer-spacing: spacing.of(4);
     bottom: 0;
     padding-right: $_arrow-outer-spacing;
     padding-left: $_arrow-inner-spacing;
-    transform: translateX(calc(-1 * #{theme.$arrow-initial-offset}));
+    transform: translateX(calc(-1 * var(--rui-local-next-arrow-initial-offset)));
 }
 
 .isRootHorizontal .arrowNext .arrowIcon {
@@ -166,16 +163,19 @@ $_arrow-outer-spacing: spacing.of(4);
 .isRootVertical .scrollingShadows::after {
     right: 0;
     left: 0;
+    width: auto;
 }
 
 .isRootVertical .scrollingShadows::before {
     top: 0;
-    transform: translateY(theme.$shadow-initial-offset);
+    height: var(--rui-local-start-shadow-size);
+    transform: translateY(var(--rui-local-start-shadow-initial-offset));
 }
 
 .isRootVertical .scrollingShadows::after {
     bottom: 0;
-    transform: translateY(calc(-1 * #{theme.$shadow-initial-offset}));
+    height: var(--rui-local-end-shadow-size);
+    transform: translateY(calc(-1 * var(--rui-local-end-shadow-initial-offset)));
 }
 
 .isRootHorizontal .viewport {
@@ -192,16 +192,19 @@ $_arrow-outer-spacing: spacing.of(4);
 .isRootHorizontal .scrollingShadows::after {
     top: 0;
     bottom: 0;
+    height: auto;
 }
 
 .isRootHorizontal .scrollingShadows::before {
     left: 0;
-    transform: translateX(theme.$shadow-initial-offset);
+    width: var(--rui-local-start-shadow-size);
+    transform: translateX(var(--rui-local-start-shadow-initial-offset));
 }
 
 .isRootHorizontal .scrollingShadows::after {
     right: 0;
-    transform: translateX(calc(-1 * #{theme.$shadow-initial-offset}));
+    width: var(--rui-local-end-shadow-size);
+    transform: translateX(calc(-1 * var(--rui-local-end-shadow-initial-offset)));
 }
 
 .isRootScrolledAtStart .scrollingShadows::before,

--- a/src/lib/components/ScrollView/__tests__/ScrollView.test.jsx
+++ b/src/lib/components/ScrollView/__tests__/ScrollView.test.jsx
@@ -7,15 +7,9 @@ import { ScrollView } from '../ScrollView';
 
 const mandatoryProps = {
   children: <div>content text</div>,
-  translations: {
-    next: 'Next',
-    previous: 'Previous',
-  },
 };
 
 describe('rendering', () => {
-  // The API of this component is not clean and is hard to test.
-  // Some tests are omitted as there are plans to change this API anyway
   it.each([
     [
       { arrows: true },
@@ -32,56 +26,6 @@ describe('rendering', () => {
       },
     ],
     [
-      { arrowsColor: 'some-color' },
-      (rootElement) => expect(rootElement).toHaveStyle({ '--rui-local-arrow-color': 'some-color' }),
-    ],
-    // `arrowsScrollStep` untested
-    // `autoScroll` untested - I have no idea how to do it - is it even possible?
-    [
-      { children: <div>content text</div> },
-      (rootElement) => expect(within(rootElement).getByText('content text')),
-    ],
-    [
-      {
-        customEndShadowStyle: {
-          background: 'style',
-          boxShadow: 'style',
-        },
-      },
-      (rootElement) => expect(rootElement).toHaveStyle({
-        '--rui-local-end-shadow-background': 'style',
-        '--rui-local-end-shadow-box-shadow': 'style',
-      }),
-    ],
-    [
-      {
-        arrows: true,
-        customNextArrow: <span>arrow</span>,
-      },
-      (rootElement) => expect(within(rootElement).getByText('arrow')),
-    ],
-    [
-      {
-        arrows: true,
-        customPrevArrow: <span>arrow</span>,
-      },
-      (rootElement) => expect(within(rootElement).getByText('arrow')),
-    ],
-    [
-      {
-        customStartShadowStyle: {
-          background: 'style',
-          boxShadow: 'style',
-        },
-      },
-      (rootElement) => expect(rootElement).toHaveStyle({
-        '--rui-local-start-shadow-background': 'style',
-        '--rui-local-start-shadow-box-shadow': 'style',
-      }),
-    ],
-    // `debounce` untested
-    // `direction` untested - interaction with other props will change significantly in #303
-    [
       {
         arrows: true,
         id: 'id',
@@ -94,6 +38,75 @@ describe('rendering', () => {
       },
     ],
     [
+      {
+        arrows: true,
+        nextArrowColor: 'color',
+        nextArrowElement: <span>next arrow</span>,
+        nextArrowInitialOffset: 'offset',
+      },
+      (rootElement) => {
+        expect(within(rootElement).getByText('next arrow'));
+        expect(rootElement).toHaveStyle({
+          '--rui-local-next-arrow-color': 'color',
+          '--rui-local-next-arrow-initial-offset': 'offset',
+        });
+      },
+    ],
+    [
+      {
+        arrows: true,
+        prevArrowColor: 'color',
+        prevArrowElement: <span>prev arrow</span>,
+        prevArrowInitialOffset: 'offset',
+      },
+      (rootElement) => {
+        expect(within(rootElement).getByText('prev arrow'));
+        expect(rootElement).toHaveStyle({
+          '--rui-local-prev-arrow-color': 'color',
+          '--rui-local-prev-arrow-initial-offset': 'offset',
+        });
+      },
+    ],
+    // `arrowsScrollStep` untested
+    // `autoScroll` untested
+    [
+      { children: <div>content text</div> },
+      (rootElement) => expect(within(rootElement).getByText('content text')),
+    ],
+    // `debounce` untested
+    [
+      { direction: 'vertical' },
+      (rootElement) => {
+        expect(rootElement).toHaveClass('isRootVertical');
+        expect(rootElement).toHaveStyle({
+          '--rui-local-end-shadow-direction': 'to top',
+          '--rui-local-start-shadow-direction': 'to bottom',
+        });
+      },
+    ],
+    [
+      { direction: 'horizontal' },
+      (rootElement) => {
+        expect(rootElement).toHaveClass('isRootHorizontal');
+        expect(rootElement).toHaveStyle({
+          '--rui-local-end-shadow-direction': 'to left',
+          '--rui-local-start-shadow-direction': 'to right',
+        });
+      },
+    ],
+    [
+      {
+        endShadowBackground: 'background',
+        endShadowInitialOffset: 'offset',
+        endShadowSize: 'size',
+      },
+      (rootElement) => expect(rootElement).toHaveStyle({
+        '--rui-local-end-shadow-background': 'background',
+        '--rui-local-end-shadow-initial-offset': 'offset',
+        '--rui-local-end-shadow-size': 'size',
+      }),
+    ],
+    [
       { scrollbar: true },
       (rootElement) => expect(rootElement).not.toHaveClass('hasRootScrollbarDisabled'),
     ],
@@ -101,8 +114,20 @@ describe('rendering', () => {
       { scrollbar: false },
       (rootElement) => expect(rootElement).toHaveClass('hasRootScrollbarDisabled'),
     ],
-    // `shadowColor` untested
-    // `shadowSize` untested
+    [
+      {
+        startShadowBackground: 'background',
+        startShadowInitialOffset: 'offset',
+        startShadowSize: 'size',
+      },
+      (rootElement) => expect(rootElement).toHaveStyle({
+        '--rui-local-start-shadow-background': 'background',
+        '--rui-local-start-shadow-direction': 'to bottom',
+        '--rui-local-start-shadow-initial-offset': 'offset',
+        '--rui-local-start-shadow-size': 'size',
+      }),
+    ],
+    // `shadows` untested
   ])('renders with props: "%s"', (testedProps, assert) => {
     const dom = render((
       <ScrollView

--- a/src/lib/components/ScrollView/_theme.scss
+++ b/src/lib/components/ScrollView/_theme.scss
@@ -1,2 +1,0 @@
-$arrow-initial-offset: var(--rui-ScrollView__arrow__initial-offset);
-$shadow-initial-offset: var(--rui-ScrollView__shadow__initial-offset);

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -910,13 +910,6 @@
     --rui-Popover__box-shadow: var(--rui-elevation-2);
 
     //
-    // ScrollView
-    // ==========
-
-    --rui-ScrollView__arrow__initial-offset: -0.5rem;
-    --rui-ScrollView__shadow__initial-offset: -1rem;
-
-    //
     // Tabs
     // ====
 


### PR DESCRIPTION
Removed custom properties:

- `--rui-ScrollView__arrow__initial-offset` in favour of `prevArrowInitialOffset` and `nextArrowInitialOffset`
- `--rui-ScrollView__shadow__initial-offset` in favour of `startShadowInitialOffset` and `endShadowInitialOffset`

Closes #303.