### PR TITLE
Fix console warning due to using ref in PropTypes just for documentation (#426)

### DIFF
--- a/src/lib/components/Button/Button.jsx
+++ b/src/lib/components/Button/Button.jsx
@@ -103,7 +103,6 @@ Button.defaultProps = {
   id: undefined,
   labelVisibility: 'xs',
   priority: 'filled',
-  ref: undefined,
   size: 'medium',
   startCorner: null,
   type: 'button',
@@ -167,14 +166,6 @@ Button.propTypes = {
    * as the value is inherited in such case.
    */
   priority: PropTypes.oneOf(['filled', 'outline', 'flat']),
-  /**
-   * Reference forwarded to the `button` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * Size of the button.
    *

--- a/src/lib/components/Button/README.mdx
+++ b/src/lib/components/Button/README.mdx
@@ -408,6 +408,10 @@ its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [button] element.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<button>` element.
+
 ## API
 
 <Props table of={Button} />
@@ -569,3 +573,4 @@ feedback state.
 
 [React synthetic events]: https://reactjs.org/docs/events.html
 [button]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/CheckboxField/CheckboxField.jsx
+++ b/src/lib/components/CheckboxField/CheckboxField.jsx
@@ -82,7 +82,6 @@ CheckboxField.defaultProps = {
   id: undefined,
   isLabelVisible: true,
   labelPosition: 'after',
-  ref: undefined,
   required: false,
   validationState: null,
   validationText: null,
@@ -120,14 +119,6 @@ CheckboxField.propTypes = {
    * Placement of the label relative to the input.
    */
   labelPosition: PropTypes.oneOf(['before', 'after']),
-  /**
-   * Reference forwarded to the `input` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * If `true`, the input will be required.
    */

--- a/src/lib/components/CheckboxField/README.mdx
+++ b/src/lib/components/CheckboxField/README.mdx
@@ -192,6 +192,10 @@ helps to improve its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [checkbox] input type.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<input>` element.
+
 ## API
 
 <Props table of={CheckboxField} />
@@ -208,3 +212,4 @@ options. On top of that, the following options are available for CheckboxField.
 
 [React synthetic events]: https://reactjs.org/docs/events.html
 [checkbox]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/FileInputField/FileInputField.jsx
+++ b/src/lib/components/FileInputField/FileInputField.jsx
@@ -90,7 +90,6 @@ FileInputField.defaultProps = {
   id: undefined,
   isLabelVisible: true,
   layout: 'vertical',
-  ref: undefined,
   required: false,
   validationState: null,
   validationText: null,
@@ -136,14 +135,6 @@ FileInputField.propTypes = {
    *
    */
   layout: PropTypes.oneOf(['horizontal', 'vertical']),
-  /**
-   * Reference forwarded to the `input` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * If `true`, the input will be required.
    */

--- a/src/lib/components/FileInputField/README.mdx
+++ b/src/lib/components/FileInputField/README.mdx
@@ -188,6 +188,10 @@ helps to improve its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [file] input type.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<input>` element.
+
 ## API
 
 <Props table of={FileInputField} />
@@ -199,3 +203,4 @@ options.
 
 [React synthetic events]: https://reactjs.org/docs/events.html
 [file]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#additional_attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/Modal/ModalCloseButton.jsx
+++ b/src/lib/components/Modal/ModalCloseButton.jsx
@@ -31,7 +31,6 @@ export const ModalCloseButton = React.forwardRef((props, ref) => {
 
 ModalCloseButton.defaultProps = {
   disabled: false,
-  ref: undefined,
 };
 
 ModalCloseButton.propTypes = {
@@ -39,14 +38,6 @@ ModalCloseButton.propTypes = {
    * If `true`, close button will be disabled.
    */
   disabled: PropTypes.bool,
-  /**
-   * Reference forwarded to the `button` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
 };
 
 export const ModalCloseButtonWithGlobalProps = withGlobalProps(ModalCloseButton, 'ModalCloseButton');

--- a/src/lib/components/Popover/Popover.jsx
+++ b/src/lib/components/Popover/Popover.jsx
@@ -42,7 +42,6 @@ export const Popover = React.forwardRef((props, ref) => {
 Popover.defaultProps = {
   placement: 'bottom',
   portalId: null,
-  ref: undefined,
 };
 
 Popover.propTypes = {
@@ -72,14 +71,6 @@ Popover.propTypes = {
    * If set, popover is rendered in the React Portal with that ID.
    */
   portalId: PropTypes.string,
-  /**
-   * Reference forwarded to the root `div` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
 };
 
 export const PopoverWithGlobalProps = withGlobalProps(Popover, 'Popover');

--- a/src/lib/components/Popover/README.mdx
+++ b/src/lib/components/Popover/README.mdx
@@ -322,6 +322,11 @@ its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [div] element.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the root native HTML `<div>` element,
+which enables [Advanced Positioning](#advanced-positioning).
+
 ## API
 
 <Props table of={Popover} />
@@ -346,3 +351,4 @@ its accessibility.
 [Floating UI]: https://floating-ui.com/docs/react-dom
 [React synthetic events]: https://reactjs.org/docs/events.html
 [div]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/ScrollView/README.mdx
+++ b/src/lib/components/ScrollView/README.mdx
@@ -506,6 +506,11 @@ accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [div] element.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the scrolling viewport native HTML
+`<div>` element.
+
 ## API
 
 <Props table of={ScrollView} />
@@ -513,3 +518,4 @@ accessibility.
 [linear gradients]: https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient
 [React synthetic events]: https://reactjs.org/docs/events.html
 [div]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/ScrollView/ScrollView.jsx
+++ b/src/lib/components/ScrollView/ScrollView.jsx
@@ -273,7 +273,6 @@ ScrollView.defaultProps = {
   prevArrowColor: undefined,
   prevArrowElement: null,
   prevArrowInitialOffset: '-0.5rem',
-  ref: undefined,
   scrollbar: true,
   shadows: true,
   startShadowBackground: 'linear-gradient(var(--rui-local-start-shadow-direction), rgba(255 255 255 / 1), rgba(255 255 255 / 0))',
@@ -357,14 +356,6 @@ ScrollView.propTypes = {
    * Initial offset of the start arrow control (transitioned). If set, the prev arrow slides in by this distance.
    */
   prevArrowInitialOffset: PropTypes.string,
-  /**
-   * Reference forwarded to the scrolling viewport `div` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * If `false`, the system scrollbar will be hidden.
    */

--- a/src/lib/components/SelectField/README.mdx
+++ b/src/lib/components/SelectField/README.mdx
@@ -669,6 +669,10 @@ to improve its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [select] element.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<select>` element.
+
 ## API
 
 <Props table of={SelectField} />
@@ -686,3 +690,4 @@ options. On top of that, the following options are available for SelectField.
 
 [React synthetic events]: https://reactjs.org/docs/events.html
 [select]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/SelectField/SelectField.jsx
+++ b/src/lib/components/SelectField/SelectField.jsx
@@ -130,7 +130,6 @@ SelectField.defaultProps = {
   id: undefined,
   isLabelVisible: true,
   layout: 'vertical',
-  ref: undefined,
   required: false,
   size: 'medium',
   validationState: null,
@@ -219,14 +218,6 @@ SelectField.propTypes = {
       ]),
     })),
   ]).isRequired,
-  /**
-   * Reference forwarded to the `select` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * If `true`, the input will be required.
    */

--- a/src/lib/components/TextArea/README.mdx
+++ b/src/lib/components/TextArea/README.mdx
@@ -348,6 +348,10 @@ to helps to improve its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [textarea] element.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<textarea>` element.
+
 ## API
 
 <Props table of={TextArea} />
@@ -359,3 +363,4 @@ options.
 
 [React synthetic events]: https://reactjs.org/docs/events.html
 [textarea]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/TextArea/TextArea.jsx
+++ b/src/lib/components/TextArea/TextArea.jsx
@@ -97,7 +97,6 @@ TextArea.defaultProps = {
   id: undefined,
   isLabelVisible: true,
   layout: 'vertical',
-  ref: undefined,
   required: false,
   size: 'medium',
   validationState: null,
@@ -144,14 +143,6 @@ TextArea.propTypes = {
   /**
    * If `true`, the input will be required.
    */
-  /**
-   * Reference forwarded to the `textarea` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   required: PropTypes.bool,
   /**
    * Size of the field.

--- a/src/lib/components/TextField/README.mdx
+++ b/src/lib/components/TextField/README.mdx
@@ -491,6 +491,10 @@ helps to improve its accessibility.
 [text][input-text], [email][input-email], [number][input-number],
 [tel][input-tel], and [password][input-password] input types.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<input>` element.
+
 ## API
 
 <Props table of={TextField} />
@@ -511,3 +515,4 @@ Head to [Forms Theming][theming-forms] to see shared form theming options.
 [input-password]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#additional_attributes
 [theming-forms]: /customize/theming/forms
 [React synthetic events]: https://reactjs.org/docs/events.html
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/TextField/TextField.jsx
+++ b/src/lib/components/TextField/TextField.jsx
@@ -107,7 +107,6 @@ TextField.defaultProps = {
   inputSize: null,
   isLabelVisible: true,
   layout: 'vertical',
-  ref: undefined,
   required: false,
   size: 'medium',
   type: 'text',
@@ -157,14 +156,6 @@ TextField.propTypes = {
    * as the value is inherited in such case.
    */
   layout: PropTypes.oneOf(['horizontal', 'vertical']),
-  /**
-   * Reference forwarded to the `input` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * If `true`, the input will be required.
    */

--- a/src/lib/components/Toggle/README.mdx
+++ b/src/lib/components/Toggle/README.mdx
@@ -188,6 +188,10 @@ helps to improve its accessibility.
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [checkbox] input type.
 
+## Forwarding ref
+
+If you provide [ref], it is forwarded to the native HTML `<input>` element.
+
 ## API
 
 <Props table of={Toggle} />
@@ -209,3 +213,4 @@ options. On top of that, the following options are available for Toggle.
 
 [React synthetic events]: https://reactjs.org/docs/events.html
 [checkbox]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/lib/components/Toggle/Toggle.jsx
+++ b/src/lib/components/Toggle/Toggle.jsx
@@ -84,7 +84,6 @@ Toggle.defaultProps = {
   id: undefined,
   isLabelVisible: true,
   labelPosition: 'after',
-  ref: undefined,
   required: false,
   validationState: null,
   validationText: null,
@@ -120,14 +119,6 @@ Toggle.propTypes = {
    * Placement of the label relative to the input.
    */
   labelPosition: PropTypes.oneOf(['before', 'after']),
-  /**
-   * Reference forwarded to the `input` element.
-   */
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line react/forbid-prop-types
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
   /**
    * If `true`, the input will be required.
    */


### PR DESCRIPTION
Closes #426 