### PR TITLE
Enable customisation of label color for required inputs

### DIFF
--- a/src/docs/customize/theming/forms.mdx
+++ b/src/docs/customize/theming/forms.mdx
@@ -39,6 +39,7 @@ The following theme options define basic appearance of all form fields.
 | `--rui-FormField__help-text__font-size`              | Help text font size                                          |
 | `--rui-FormField__help-text__font-style`             | Help text font style, e.g. italic                            |
 | `--rui-FormField__help-text__color`                  | Help text color                                              |
+| `--rui-FormField--required__label__color`            | Color of required input labels                               |
 | `--rui-FormField--required__sign`                    | Text appended to required input labels                       |
 | `--rui-FormField--required__sign__color`             | Color of text appended to required input labels              |
 

--- a/src/lib/styles/theme/_form-fields.scss
+++ b/src/lib/styles/theme/_form-fields.scss
@@ -13,6 +13,7 @@ $label-font-size: var(--rui-FormField__label__font-size);
 $help-text-font-size: var(--rui-FormField__help-text__font-size);
 $help-text-font-style: var(--rui-FormField__help-text__font-style);
 $help-text-color: var(--rui-FormField__help-text__color);
+$required-label-color: var(--rui-FormField--required__label__color);
 $required-sign: var(--rui-FormField--required__sign);
 $required-sign-color: var(--rui-FormField--required__sign__color);
 

--- a/src/lib/styles/tools/form-fields/_foundation.scss
+++ b/src/lib/styles/tools/form-fields/_foundation.scss
@@ -12,6 +12,8 @@
 }
 
 @mixin label-required() {
+    color: var(--rui-local-surrounding-text-color, #{theme.$required-label-color});
+
     &::after {
         content: theme.$required-sign;
         color: theme.$required-sign-color;

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -738,6 +738,7 @@
     --rui-FormField__help-text__font-size: var(--rui-typography-size-small);
     --rui-FormField__help-text__font-style: normal;
     --rui-FormField__help-text__color: var(--rui-color-gray-500);
+    --rui-FormField--required__label__color: inherit;
     --rui-FormField--required__sign: "\00a0*"; // 2.
     --rui-FormField--required__sign__color: var(--rui-color-gray-500);
 


### PR DESCRIPTION
On top of the required sign itself, whole labels of required inputs can now be a different color:

<img width="262" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/204314349-a87bd590-35b3-4f58-94f7-84594be5d8a6.png">
