### PR TITLE
Extend focus box shadow with outline (#240)

### DIFF
--- a/src/docs/foundation/accessibility.mdx
+++ b/src/docs/foundation/accessibility.mdx
@@ -53,11 +53,12 @@ Many people use keyboard to control their computer. Interactive elements in
 React UI are **highlighted on focus** so keyboard users can easily tab over
 them and see what control currently has focus.
 
-Check form fields like [CheckboxField](/components/checkbox-field) or
-[Toggle](/components/toggle) obtain a blue outline on focus (which is to be
-[spread over all interactive elements](https://github.com/react-ui-org/react-ui/issues/240)
-eventually). Appearance of focus highlight can be adjusted via the
-`--rui-focus-box-shadow` custom property (see
-[Theming](/customize/theming/overview) to learn how).
+All interactive elements obtain a blue outline on focus. Appearance of the focus
+highlight can be [adjusted](/customize/theming/overview) with the following
+custom properties:
+
+- `--rui-focus-outline`,
+- `--rui-focus-outline-offset`,
+- `--rui-focus-box-shadow`.
 
 📖 [Read more about keyboard accessibility at MDN.](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard)

--- a/src/lib/components/FileInputField/FileInputField.jsx
+++ b/src/lib/components/FileInputField/FileInputField.jsx
@@ -54,7 +54,6 @@ export const FileInputField = React.forwardRef((props, ref) => {
         <div className={styles.inputContainer}>
           <input
             {...transferProps(restProps)}
-            className={styles.input}
             disabled={disabled}
             id={id}
             ref={ref}

--- a/src/lib/components/FileInputField/FileInputField.scss
+++ b/src/lib/components/FileInputField/FileInputField.scss
@@ -17,10 +17,6 @@
     @include box-field-elements.input-container();
 }
 
-.input {
-    @include accessibility.focus-ring();
-}
-
 .helpText,
 .validationText {
     @include foundation.help-text();

--- a/src/lib/styles/generic/_forms.scss
+++ b/src/lib/styles/generic/_forms.scss
@@ -1,9 +1,13 @@
-// Remove focus outline as we implement custom appearance of focus state.
-button:focus,
-input:focus,
-select:focus,
-textarea:focus {
-    outline: 0;
+@use "../tools/accessibility";
+
+// Remove focus outline as we implement custom appearance of focus state. Increase specificity where necessary to
+// override normalize.css.
+:where(button, input, select, textarea):focus {
+    outline: none;
+}
+
+:is(a, button, input, select, textarea, [type="button"], [type="submit"]) {
+    @include accessibility.focus-ring();
 }
 
 // Reset Chrome and Firefox behaviour which sets a `min-width: min-content;` on fieldsets.

--- a/src/lib/styles/theme/_accessibility.scss
+++ b/src/lib/styles/theme/_accessibility.scss
@@ -1,2 +1,4 @@
 $tap-target-size: var(--rui-tap-target-size);
+$focus-outline: var(--rui-focus-outline);
+$focus-outline-offset: var(--rui-focus-outline-offset);
 $focus-box-shadow: var(--rui-focus-box-shadow);

--- a/src/lib/styles/tools/_accessibility.scss
+++ b/src/lib/styles/tools/_accessibility.scss
@@ -46,6 +46,8 @@
 
 @mixin focus-ring() {
     &:focus-visible {
+        outline: theme.$focus-outline;
+        outline-offset: theme.$focus-outline-offset;
         box-shadow: theme.$focus-box-shadow;
     }
 }

--- a/src/lib/theme.scss
+++ b/src/lib/theme.scss
@@ -149,7 +149,9 @@
 
     // Accessibility
     --rui-tap-target-size: 10mm;
-    --rui-focus-box-shadow: 0 0 0 0.2em var(--rui-color-active-focus);
+    --rui-focus-outline: 0.2em solid var(--rui-color-active-focus);
+    --rui-focus-outline-offset: 1px;
+    --rui-focus-box-shadow: none;
 
     // Bottom spacings
     --rui-spacing-bottom-default: var(--rui-spacing-5);


### PR DESCRIPTION
New custom properties:

- `--rui-focus-outline`
- `--rui-focus-outline-offset`

Migration:

You may need to turn off `--rui-focus-outline` if already using a custom focus box shadow via `--rui-focus-box-shadow`.

Closes #240.