### PR TITLE
Automatically mark PRs with `task/*` branches as features

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,7 +1,7 @@
 BC: bc/*
-feature: feature/*
-bug: bugfix/*
+feature: [feature/*, task/*]
+bug: [bug/*, bugfix/*]
 refactoring: refactoring/*
-documentation: ['docs/*', 'documentation/*']
+documentation: [docs/*, documentation/*]
 maintenance: maintenance/*
 'skip changelog': release/*


### PR DESCRIPTION
So it's easier to switch between projects for the developers.