### PR TITLE
Introduce `CODEOWNERS` file to define responsibility for code in the repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,23 @@
+# Default owners for code review
+*              @developers
+
+# Default owners for file types
+*.js           @mbohal @bedrich-schindler @developers
+*.jsx          @mbohal @bedrich-schindler @developers
+*.md           @adamkudrna @developers
+*.scss         @adamkudrna @developers
+
+# Default owners for directories
+/docker        @mbohal @bedrich-schindler @developers
+/src/docs      @adamkudrna @developers
+
+# Default owners for specific files
+/.browserslistrc            @adamkudrna @developers
+/.eslintrc                  @mbohal @bedrich-schindler @developers
+/.markdownlint.jsonc        @adamkudrna @developers
+/babel.config.js            @mbohal @bedrich-schindler @developers
+/docker-compose.yml         @mbohal @bedrich-schindler @developers
+/jest.config.js             @mbohal @bedrich-schindler @developers
+/postcss.config.js          @adamkudrna @developers
+/stylelint.config.js        @adamkudrna @developers
+/webpack.config.babel.js    @mbohal @bedrich-schindler @developers


### PR DESCRIPTION
Define who is responsible for code in this repository.

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners