### PR TITLE
Move `transferProps` back from `fieldset` to `input` in `RadioField` (#481)

### DIFF
--- a/src/components/Radio/README.md
+++ b/src/components/Radio/README.md
@@ -281,8 +281,8 @@ It's possible to disable just some options or the whole set.
 In addition to the options below in the [component's API](#api) section, you
 can specify [React synthetic events] or you can **add whatever HTML attribute
 you like.** All attributes that don't interfere with the API are forwarded to
-the native HTML `<input>`. This enables making the component interactive and helps
-to improve its accessibility.
+the native HTML `<input>` elements. This enables making the component
+interactive and helps to improve its accessibility.
 
 👉 Refer to the MDN reference for the full list of supported attributes of the
 [radio] input type.

--- a/src/components/Radio/Radio.jsx
+++ b/src/components/Radio/Radio.jsx
@@ -26,7 +26,6 @@ export const Radio = ({
 
   return (
     <fieldset
-      {...transferProps(restProps)}
       className={classNames(
         styles.root,
         context && styles.isRootInFormLayout,
@@ -68,6 +67,7 @@ export const Radio = ({
                   key={key}
                 >
                   <input
+                    {...transferProps(restProps)}
                     checked={restProps.onChange
                       ? (value === option.value) || false
                       : undefined}
@@ -75,10 +75,6 @@ export const Radio = ({
                     disabled={disabled || option.disabled}
                     id={id && `${id}__item__${key}`}
                     name={id}
-                    // The change is handled by the `<fieldset>` element. This is a placeholder to prevent React from
-                    // showing the warning about uncontrolled input: "You provided a `checked` prop to a form field
-                    // without an `onChange` handler."
-                    onChange={() => {}}
                     type="radio"
                     value={option.value}
                   />


### PR DESCRIPTION
Closes #481 