### PR TITLE
Use 4 spaces to indent nested lists in MD so MkDocs can render them correctly (#486)

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -2,7 +2,10 @@
 
 {
   "default": true,
-  "MD033": false, // Allow inline JSX.
+  "MD007": { // Unordered list indentation
+    "indent": 4 // 4 spaces so MkDocs can render nested lists correctly
+  },
+  "MD033": false, // Allow inline JSX and custom web components
   "MD024": false, // Allow duplicate headings
   "line-length": {
     "code_block_line_length": 120,

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -433,10 +433,10 @@ Where:
 - `<INTERACTION STATE>` is one of `default`, `hover`, `active`, or `disabled`
   (the last one being optional),
 - `<PROPERTY>` is one of:
-  - `color`, `border-color`, `background`, or `box-shadow` for the `filled`
-    priority,
-  - `color`, `border-color`, or `background` for the `outline` priority,
-  - `color` or `background` for the `flat` priority.
+    - `color`, `border-color`, `background`, or `box-shadow` for the `filled`
+      priority,
+    - `color`, `border-color`, or `background` for the `outline` priority,
+    - `color` or `background` for the `flat` priority.
 
 ### Theming Sizes
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -47,8 +47,8 @@ See [API](#api) for all available options.
 Card is decomposed into the following components:
 
 - [Card](#api)
-  - [CardBody](#cardbody)
-  - [CardFooter](#cardfooter)
+    - [CardBody](#cardbody)
+    - [CardFooter](#cardfooter)
 
 Aside from the [CardBody](#cardbody) element, you can add a
 [CardFooter](#cardfooter) to better separate your card's actions from the rest

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -105,13 +105,13 @@ See [API](#api) for all available options.
 Modal is decomposed into the following components:
 
 - Modal
-  - [ModalHeader](#modalheader)
-    - ModalTitle
-    - ModalCloseButton
-  - [ModalBody](#modalbody)
-    - ModalContent
-      (may be wrapped with [ScrollView](/components/ScrollView))
-  - [ModalFooter](#modalfooter)
+    - [ModalHeader](#modalheader)
+        - ModalTitle
+        - ModalCloseButton
+    - [ModalBody](#modalbody)
+        - ModalContent
+          (may be wrapped with [ScrollView](/components/ScrollView))
+    - [ModalFooter](#modalfooter)
 
 Using different combinations, you can compose different kinds of modals,
 e.g. dialog modal, blocking modal, scrollable modal, etc.

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -25,11 +25,11 @@ React.createElement(() => {
   const [modalOpen, setModalOpen] = React.useState(false);
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -121,11 +121,11 @@ React.createElement(() => {
   const [modalOpen, setModalOpen] = React.useState(null);
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -276,11 +276,11 @@ React.createElement(() => {
   const [variant, setVariant] = React.useState(null);
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -410,11 +410,11 @@ React.createElement(() => {
   const [modalJustify, setModalJustify] = React.useState('center');
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -533,11 +533,11 @@ React.createElement(() => {
   const [modalSize, setModalSize] = React.useState('small');
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -617,11 +617,11 @@ React.createElement(() => {
   const [modalOpen, setModalOpen] = React.useState(false);
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -685,11 +685,11 @@ React.createElement(() => {
   const [modalOpen, setModalOpen] = React.useState(false);
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -749,11 +749,11 @@ React.createElement(() => {
   const [modalPosition, setModalPosition] = React.useState('center');
   const modalPrimaryButtonRef = React.useRef();
   const modalCloseButtonRef = React.useRef();
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>
@@ -930,12 +930,12 @@ React.createElement(() => {
         ut, imperdiet a, venenatis vitae, justo.
       </p>
     </ModalContent>
-  )
+  );
+  {/*
+    The `preventScrollUnderneath` feature is necessary for Modals to work in
+    React UI docs. You may not need it in your application.
+  */}
   return (
-    {/*
-      The `preventScrollUnderneath` feature is necessary for Modals to work in
-      React UI docs. You may not need it in your application.
-    */}
     <RUIProvider globalProps={{
       Modal: { preventScrollUnderneath: window.document.documentElement }
     }}>


### PR DESCRIPTION
- Use 4 spaces to indent nested lists in MD so MkDocs can render them correctly (#486)
- Fix `Modal` previews not being rendered because of a misplaced comment

Closes #486.