### PR TITLE
Fix `Modal` previews being overlapped by MkDocs header (#471)

### DIFF
--- a/src/docs/_overrides/main.html
+++ b/src/docs/_overrides/main.html
@@ -22,7 +22,7 @@
   <script src="/docs/_assets/js/ruiSwatch.js" type="application/javascript"></script>
 
   <!-- Then load and init Docoff -->
-  <script crossorigin src="https://unpkg.com/@react-ui-org/docoff@0.5.3/public/generated/bundle.js"></script>
+  <script crossorigin src="https://unpkg.com/@react-ui-org/docoff@0.5.4/public/generated/bundle.js"></script>
 
   <!-- Then load non-Docoff code highlighiting -->
   <script src="https://unpkg.com/prismjs@1.29.0/components/prism-core.min.js"></script>


### PR DESCRIPTION
Install the latest version of `docoff` that no longer establishes new stacking context within previews.

<img width="1013" alt="obrazek" src="https://github.com/react-ui-org/react-ui/assets/5614085/b79808b2-3f97-4641-b05e-8e018e2e2610">

Closes #471.