### PR TITLE
Create `.env` file automatically after `npm install` (don't overwrite if already exists)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,13 @@ docker compose run --rm node_shell
 
 #### Run the Dev Server
 
-1. Install dependencies (run within `node_shell`):
+1. **Within `node_shell`:** Install dependencies:
 
     ```bash
     npm ci
     ```
 
-2. Run development server (run on host):
+2. **On host:** Run development server:
 
     ```bash
     docker compose up node_dev_server mkdocs_dev_server
@@ -46,25 +46,25 @@ docker compose run --rm node_shell
 
 #### Build the Project
 
-1. Make sure the dev server is not running (run on host):
+1. **On host:** Make sure the dev server is not running:
 
     ```bash
     docker compose down
     ```
 
-2. Install dependencies (run within `node_shell`):
+2. **Within `node_shell`:** Install dependencies:
 
     ```bash
     npm ci
     ```
 
-3. Build JS (run on host):
+3. **On host:** Build JS:
 
     ```bash
     docker compose run --rm node_build_site
     ```
 
-4. Build mkDocs (run on host):
+4. **On host:** Build mkDocs:
 
     ```bash
     docker compose run --rm mkdocs_build_site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,16 +15,7 @@ This allows running the documentation site which serves as a development platfor
 
 Review the default env variable values in the `docker-compose.yml` file.
 The defaults should work for most systems, but can be changed if needed.
-
-To change them:
-
-1. Create a `.env` file from the template:
-
-    ```bash
-    cp .env.dist .env
-    ```
-
-2. Edit the new `.env` file as needed
+To change them, edit the `.env` file as needed.
 
 ### Use Docker Compose
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint": "npm run eslint && npm run markdownlint && npm run stylelint",
     "markdownlint": "markdownlint-cli2 \"CONTRIBUTING.md\" \"README.md\" \"RELEASING.md\" \"src/**/*.md\"",
     "postbuild": "npm run copy",
+    "postinstall": "cp -n .env.dist .env || true",
     "precopy": "rm -rf dist && mkdir dist",
     "prepublishOnly": "npm run build",
     "start": "webpack --watch --mode=development",


### PR DESCRIPTION
- Create `.env` file automatically after `npm install` (don't overwrite if already exists)
- Improve contributing instructions so it's easier to find what to run where