### PR TITLE
#532 Fix/forgottent console log in dev mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends" : [
+  "extends": [
     "@visionappscz/eslint-config-visionapps"
   ],
   "env": {
@@ -17,6 +17,7 @@
   ],
   "parser": "@babel/eslint-parser",
   "rules": {
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "no-console": "error"
   }
 }

--- a/src/components/_helpers/__tests__/transferProps.test.js
+++ b/src/components/_helpers/__tests__/transferProps.test.js
@@ -20,13 +20,16 @@ describe('transferProps', () => {
     const expectedProps = { propA: 'value' };
 
     let errorString;
+    // eslint-disable-next-line no-console
     const originalConsoleError = console.error;
+    // eslint-disable-next-line no-console
     console.error = (error) => {
       errorString = error;
     };
     expect(transferProps(props)).toEqual(expectedProps);
     expect(errorString).toEqual('Invalid prop(s) supplied to the "transferProps" function: "className", "contentEditable"');
 
+    // eslint-disable-next-line no-console
     console.error = originalConsoleError;
   });
 });

--- a/src/components/_helpers/transferProps.js
+++ b/src/components/_helpers/transferProps.js
@@ -24,7 +24,6 @@ export const transferProps = (props) => {
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
-    console.log('props', props);
     const invalidProps = [
       'children', // It is always either handled by the component itself or not supported.
       'className', // Classes are set by component authors, changing it arbitrarily might break things.


### PR DESCRIPTION
PR Description:

Changes Made:
Removed the console.log statement from the codebase to improve code cleanliness and prevent unnecessary logging. Additionally, added a linting rule to disallow console.log statements unless explicitly allowed by an eslint-disable statement.

Reasoning:
Removing console.log statements helps maintain a clean codebase and prevents clutter in the console output. By enforcing a linting rule to disallow console.log statements, we ensure consistency in code quality and adherence to best practices.

Impact:

Enhances code readability and maintainability by removing unnecessary logging statements.
Helps prevent accidental logging of sensitive information in production environments.
Encourages developers to use more robust debugging techniques, such as using breakpoints or logging to a dedicated debugging tool.
Related Issue:
This PR addresses issue #532. [Link to issue](https://github.com/react-ui-org/react-ui/issues/532)
