### PR TITLE
Make text links underlined by default #577

### DIFF
--- a/src/components/Alert/Alert.module.scss
+++ b/src/components/Alert/Alert.module.scss
@@ -25,8 +25,8 @@
         padding: theme.$padding;
     }
 
-    .close,
-    .icon {
+    .icon,
+    .close {
         height: settings.$min-height;
         color: var(--rui-local-foreground-color);
     }
@@ -46,11 +46,8 @@
         line-height: settings.$line-height;
     }
 
-    .message :is(a, strong) {
-        font-weight: theme.$emphasis-font-weight;
-    }
-
     .message strong {
+        font-weight: theme.$emphasis-font-weight;
         color: var(--rui-local-foreground-color);
     }
 

--- a/src/components/Alert/README.md
+++ b/src/components/Alert/README.md
@@ -201,14 +201,14 @@ helps to improve its accessibility.
 
 ### Common Theming Options
 
-| Custom Property                                      | Description                                                  |
-|------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-Alert__padding`                               | Padding between border and message                           |
-| `--rui-Alert__font-weight`                           | Message font weight                                          |
-| `--rui-Alert__border-width`                          | Border width                                                 |
-| `--rui-Alert__border-radius`                         | Corner radius                                                |
-| `--rui-Alert__emphasis__font-weight`                 | Font weight of text emphasised with `<strong>`               |
-| `--rui-Alert__stripe__width`                         | Width of the border at the start of the Alert                |
+| Custom Property                      | Description                                    |
+|--------------------------------------|------------------------------------------------|
+| `--rui-Alert__padding`               | Padding between border and message             |
+| `--rui-Alert__font-weight`           | Message font weight                            |
+| `--rui-Alert__border-width`          | Border width                                   |
+| `--rui-Alert__border-radius`         | Corner radius                                  |
+| `--rui-Alert__emphasis__font-weight` | Font weight of text emphasised with `<strong>` |
+| `--rui-Alert__stripe__width`         | Width of the border at the start of the Alert  |
 
 ### Theming Variants
 

--- a/src/styles/elements/_links.scss
+++ b/src/styles/elements/_links.scss
@@ -2,6 +2,7 @@
 
 a {
     text-decoration: links.$decoration;
+    text-underline-offset: links.$underline-offset;
     color: links.$color;
 
     &:hover {

--- a/src/styles/theme/_links.scss
+++ b/src/styles/theme/_links.scss
@@ -1,5 +1,6 @@
 $color: var(--rui-local-link-color, var(--rui-color-text-link));
 $decoration: var(--rui-text-decoration-link);
+$underline-offset: var(--rui-underline-offset-link);
 $hover-color: var(--rui-local-link-color-hover, var(--rui-color-text-link-hover));
 $hover-decoration: var(--rui-text-decoration-link-hover);
 $active-color: var(--rui-local-link-color-active, var(--rui-color-text-link-active));

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -109,7 +109,8 @@
         --rui-line-height-small: 1.25;
 
         // Text decorations
-        --rui-text-decoration-link: none;
+        --rui-underline-offset-link: 0.1875em;
+        --rui-text-decoration-link: underline;
         --rui-text-decoration-link-hover: underline;
         --rui-text-decoration-link-active: underline;
 


### PR DESCRIPTION
## 1. ~~Allow configuration~~ Remove configurable font weight of links inside `Alert` #577

~~Default font weight of links is now set to "regular" so it is consistent with other links in React UI. However, it remains configurable because of downstream project requirements.~~

Links in `Alert` now inherit the font weight which is consistent with other links in React UI.

## 2. Make text links underlined by default #577

Since the color inheritance for links has been introduced in #492, links in e.g. validation messages cannot be distinguished from regular text until hovered. We chose to underline all text links by default to make those links discoverable by users.

Closes #577