### PR TITLE
Update Github Workflows to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/broken-links-check.yml
+++ b/.github/workflows/broken-links-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   broken_link_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Check react-ui.io for broken links
     steps:
       - name: Check for broken links

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
   build:
     name: Build distribution CSS and JS
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node: [ 20, 22 ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       # required for all workflows

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     name: Build Docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-links-check.yml
+++ b/.github/workflows/external-links-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   broken_link_check:
     name: Markdown link check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
   block-merge-with-autosquash-commits:
     name: Block merge with autosquash commits
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Block merge with autosquash commits

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-meta.yml
+++ b/.github/workflows/pull-request-meta.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   process_pr_meta:
     name: Process PR meta
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Assign to author
         uses: kentaro-m/auto-assign-action@v2.0.0 # Specify also the minor version because v2 does not exist

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test_and_build:
     name: Test and build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.check_package_version.outputs.version }}
       version_changed: ${{ steps.check_package_version.outputs.changed }}
@@ -51,7 +51,7 @@ jobs:
       contents: write
     needs: [test_and_build]
     if: needs.test_and_build.outputs.version_changed == 'false'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Draft release on GitHub
         uses: release-drafter/release-drafter@v6
@@ -62,7 +62,7 @@ jobs:
     name: Publish release draft
     needs: [test_and_build]
     if: needs.test_and_build.outputs.version_changed == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     name: Publish to npm
     needs: [test_and_build, publish_release_draft_on_version_bump]
     if: needs.test_and_build.outputs.version_changed == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
       contents: write
     needs: [test_and_build, publish_release_draft_on_version_bump]
     if: needs.test_and_build.outputs.version_changed == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,3 +1,3 @@
-FROM        node:20
+FROM        node:22
 RUN         mkdir /workspace
 WORKDIR     /workspace


### PR DESCRIPTION
This is required by upcoming pull request as Ubuntu 20.04 is old and generates incorrect snapshots as latest Playwright Docker Image uses Ubuntu 24.04. 