### PR TITLE
Introduce border color theming option for default `Card`

### DIFF
--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -12,7 +12,7 @@
         flex-direction: column;
         min-width: 0; // 1.
         color: var(--rui-local-color);
-        border: theme.$border-width solid var(--rui-local-border-color, transparent);
+        border: theme.$border-width solid var(--rui-local-border-color, theme.$border-color);
         border-radius: theme.$border-radius;
         background-color: var(--rui-local-background-color, theme.$background-color);
     }

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -289,16 +289,17 @@ Separate your card actions with CardFooter. See
 
 ### Common Theming Options
 
-| Custom Property                                      | Description                                                  |
-|------------------------------------------------------|--------------------------------------------------------------|
-| `--rui-Card__padding`                                | Padding shared by card header, body and footer               |
-| `--rui-Card__border-width`                           | Border width                                                 |
-| `--rui-Card__border-radius`                          | Corner radius                                                |
-| `--rui-Card__background-color`                       | Card background color                                        |
-| `--rui-Card--dense__padding`                         | Padding of dense card                                        |
-| `--rui-Card--raised__box-shadow`                     | Box shadow of raised card                                    |
-| `--rui-Card--disabled__background-color`             | Card background color in disabled state                      |
-| `--rui-Card--disabled__opacity`                      | Card opacity in disabled state                               |
+| Custom Property                          | Description                                    |
+|------------------------------------------|------------------------------------------------|
+| `--rui-Card__padding`                    | Padding shared by card header, body and footer |
+| `--rui-Card__border-width`               | Border width                                   |
+| `--rui-Card__border-color`               | Border color                                   |
+| `--rui-Card__border-radius`              | Corner radius                                  |
+| `--rui-Card__background-color`           | Card background color                          |
+| `--rui-Card--dense__padding`             | Padding of dense card                          |
+| `--rui-Card--raised__box-shadow`         | Box shadow of raised card                      |
+| `--rui-Card--disabled__background-color` | Card background color in disabled state        |
+| `--rui-Card--disabled__opacity`          | Card opacity in disabled state                 |
 
 ### Theming Variants
 

--- a/src/components/Card/_theme.scss
+++ b/src/components/Card/_theme.scss
@@ -1,5 +1,6 @@
 $padding: var(--rui-Card__padding);
 $border-width: var(--rui-Card__border-width);
+$border-color: var(--rui-Card__border-color);
 $border-radius: var(--rui-Card__border-radius);
 $background-color: var(--rui-Card__background-color);
 

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -825,6 +825,7 @@
 
         --rui-Card__padding: var(--rui-dimension-space-4);
         --rui-Card__border-width: var(--rui-dimension-border-width-1);
+        --rui-Card__border-color: var(--rui-color-border-primary);
         --rui-Card__border-radius: var(--rui-dimension-radius-2);
         --rui-Card__background-color: var(--rui-color-background-layer-1);
         --rui-Card--dense__padding: var(--rui-dimension-space-2);


### PR DESCRIPTION
New `--rui-Card__border-color` custom property has been introduced to define Card's default border color.

The default value is border primary, so `Card`s are now bordered by default to be distinguishable on default `Paper`.

Before:

<img width="721" alt="obrazek" src="https://github.com/user-attachments/assets/02d841cd-b6c2-4e97-b7a0-55bfa169d7c4" />

After:

<img width="717" alt="obrazek" src="https://github.com/user-attachments/assets/89e6a437-f4ec-4ecf-a213-f42bf0fad44e" />
