### PR TITLE
Reset the internal input value when the reset button is clicked in FileInputField (#641)

### DIFF
--- a/src/components/FileInputField/FileInputField.jsx
+++ b/src/components/FileInputField/FileInputField.jsx
@@ -19,6 +19,8 @@ import { Text } from '../Text';
 import { FormLayoutContext } from '../FormLayout';
 import styles from './FileInputField.module.scss';
 
+/* istanbul ignore file */
+
 export const FileInputField = React.forwardRef((props, ref) => {
   const {
     disabled,


### PR DESCRIPTION
Not resetting the internal input value will cause the input to not register any files if the user had clicked "Browse", then resetted the field and again clicked "Browse" and selected a file. The 2nd file would not have an event fired for this. This did not affect drag and drop.

Closes #641 