### PR TITLE
Fix modal closing when selection ended outside of the modal (#645)

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -61,6 +61,7 @@ export const Modal = ({
   ...restProps
 }) => {
   const internalDialogRef = useRef();
+  const mouseDownTarget = useRef(null);
 
   useEffect(() => {
     internalDialogRef.current.showModal();
@@ -79,7 +80,13 @@ export const Modal = ({
     [closeButtonRef, restProps.onCancel],
   );
   const onClick = useCallback(
-    (e) => dialogOnClickHandler(e, closeButtonRef, internalDialogRef, allowCloseOnBackdropClick),
+    (e) => dialogOnClickHandler(
+      e,
+      closeButtonRef,
+      internalDialogRef,
+      allowCloseOnBackdropClick,
+      mouseDownTarget.current,
+    ),
     [allowCloseOnBackdropClick, closeButtonRef, internalDialogRef],
   );
   const onClose = useCallback(
@@ -101,11 +108,17 @@ export const Modal = ({
       primaryButtonRef,
     ],
   );
+
+  const onMouseDown = useCallback((e) => {
+    mouseDownTarget.current = e.target;
+  }, []);
+
   const events = {
     onCancel,
     onClick,
     onClose,
     onKeyDown,
+    onMouseDown,
   };
 
   if (portalId === null) {

--- a/src/components/Modal/_helpers/dialogOnClickHandler.js
+++ b/src/components/Modal/_helpers/dialogOnClickHandler.js
@@ -17,9 +17,15 @@ export const dialogOnClickHandler = (
   closeButtonRef,
   dialogRef,
   allowCloseOnBackdropClick,
+  mouseDownTarget,
 ) => {
   // If it is not allowed to close modal on backdrop click, do nothing.
   if (!allowCloseOnBackdropClick) {
+    return;
+  }
+
+  // If the click started on the inside of the dialog, do nothing.
+  if (e.target !== mouseDownTarget) {
     return;
   }
 


### PR DESCRIPTION
The modal would close when the user selected something outside the modal and ended the selection outside of the modal.