### PR TITLE
Fix `ScrollView` scroll position issues (#501)

### DIFF
--- a/src/components/ScrollView/_hooks/useScrollPositionHook.js
+++ b/src/components/ScrollView/_hooks/useScrollPositionHook.js
@@ -1,10 +1,10 @@
 import {
-  useLayoutEffect,
   useRef,
+  useEffect,
 } from 'react';
 import { getElementsPositionDifference } from '../_helpers/getElementsPositionDifference';
 
-export const useScrollPosition = (effect, dependencies, contentEl, viewportEl, wait) => {
+export const useScrollPosition = (effect, contentEl, viewportEl, wait) => {
   const throttleTimeout = useRef(null);
 
   const callBack = (wasDelayed = false) => {
@@ -15,7 +15,7 @@ export const useScrollPosition = (effect, dependencies, contentEl, viewportEl, w
     }
   };
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const viewport = viewportEl.current;
 
     const handleScroll = () => {
@@ -34,7 +34,7 @@ export const useScrollPosition = (effect, dependencies, contentEl, viewportEl, w
       clearTimeout(throttleTimeout.current);
       viewport.removeEventListener('scroll', handleScroll);
     };
-  }, dependencies); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 };
 
 export default useScrollPosition;


### PR DESCRIPTION
ScrollView would not update if the size of the content changed due to style or window size changes.

ScrollView would get stuck in a state where the arrows would not update when the user scrolled fast back and forth.