### PR TITLE
Fix modal closing when Escape key is pressed inside a OS dialog

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -76,7 +76,12 @@ export const Modal = ({
   useModalScrollPrevention(preventScrollUnderneath);
 
   const onCancel = useCallback(
-    (e) => dialogOnCancelHandler(e, closeButtonRef, restProps.onCancel),
+    (e) => {
+      if (e.target !== internalDialogRef.current) {
+        return;
+      }
+      dialogOnCancelHandler(e, closeButtonRef, restProps.onCancel);
+    },
     [closeButtonRef, restProps.onCancel],
   );
   const onClick = useCallback(


### PR DESCRIPTION
Fixes a behavior when, for example a file open dialog is open in a Modal and the Escape key is pressed, the dialog and modal closes.