### PR TITLE
Tighten `engines` and `devEngines`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,21 +2,83 @@ name: Build
 
 on: [ pull_request ]
 
+# We build distribution CSS and JS on both the active LTS and previous LTS Node.js versions,
+# to ensure compatibility across a wider range of environments. Those versions are defined
+# in package.json `devEngines` field and must match the versions defined in `env` section below.
+#
+# As package.json does not support comments, we document the version mapping here.
+#
+# `engines` field in package.json defines the minimum required Node.js version for running the package.
+# We set it to the first released previous LTS version of Node.js. This means we allow users
+# to run the package on this version and any later versions.
+#
+#  "engines": {
+#    "node": ">=22.11.0"
+#  }
+#
+# `devEngines` field in package.json defines the Node.js versions used for development and building.
+# We set both to the first released active and previous LTS versions of Node.js. We also set
+# the npm version to the version of npm bundled with the first released active LTS Node.js version.
+# This means we strictly require one of those versions for development and building.
+#
+#  "devEngines": {
+#    "runtime": {
+#      "name": "node",
+#      "version": "^22.11.0 || ^24.11.0",
+#      "onFail": "error"
+#    },
+#    "packageManager": {
+#      "name": "npm",
+#      "version": "^11.6.1",
+#      "onFail": "error"
+#    }
+#  }
+#
+# Versions defined in `env` use major version numbers only to install the latest minor/patch.
+
+env:
+  NODE_ACTIVE_LTS_VERSION: 24
+  NODE_PREVIOUS_LTS_VERSION: 22
+  NPM_VERSION: 11
+
 jobs:
-  build:
-    name: Build distribution CSS and JS
+  build_on_node_previous_lts:
+    name: Build distribution CSS and JS (Node Previous LTS)
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        node: [ 22, 24 ]
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Set up Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+      - name: Set up Node.js (${{ env.NODE_PREVIOUS_LTS_VERSION }})
+        uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ env.NODE_PREVIOUS_LTS_VERSION }}
+          cache: npm
+        continue-on-error: true
+
+      - name: Install npm@${{ env.NPM_VERSION }}
+        run: npm install -g npm@${{ env.NPM_VERSION }}
+
+      - name: Print Node.js and npm version
+        run: node --version && npm --version
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  build_on_node_active_lts:
+    name: Build distribution CSS and JS (Node Active LTS)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js (${{ env.NODE_ACTIVE_LTS_VERSION }})
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_ACTIVE_LTS_VERSION }}
           cache: npm
 
       - name: Print Node.js and npm version

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,19 @@
         "webpack-visualizer-plugin2": "^2.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.11.0"
+      },
+      "devEngines": {
+        "runtime": {
+          "name": "node",
+          "version": "^22.11.0 || ^24.11.0",
+          "onFail": "error"
+        },
+        "packageManager": {
+          "name": "npm",
+          "version": "^11.6.1",
+          "onFail": "error"
+        }
       },
       "peerDependencies": {
         "prop-types": "^15.8.0",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,17 @@
     "url": "https://github.com/react-ui-org/react-ui"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.11.0"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "22.x || 24.x",
+      "version": "^22.11.0 || ^24.11.0",
       "onFail": "error"
     },
     "packageManager": {
       "name": "npm",
+      "version": "^11.6.1",
       "onFail": "error"
     }
   },


### PR DESCRIPTION
`engines` requires `node` version `>=22.11.0` instead of `>=22`, while `22.11.0` is first long term support minor version of this major version.

`devEngines` requires `node` version `^22.11.0 || ^24.11.0` instead of `22.x || 24.x`, while `22.11.0`  and `24.11.0` are first long term support minor versions of those major versions. `devEngines` now requires `npm` version `^11.6.1` as it is first `npm` version delivered by `node` in version `24.11.0`. We require single major version of `npm` to generate `package-lock.json` of compatible structure. This would not be possible without requiring specific version of `npm`.

`.github/workflows/build.yml` requires to split `build` job between `build_on_node_active_lts` to `build_on_node_previous_lts` due to fact that `build_on_node_previous_lts` requires to install newer `npm` and its `Set up Node.js` may fail due to this. This is due to `actions/setup-node@v6` that cannot install specific `npm` version, but fails with incompatible version defined in `devEngines`.

`.github/workflows/build.yml` sets only major version of runtime engines to use the latest.