### PR TITLE
Drop access token in favor of OICD to authenticate against npm (#685)

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test_and_build:
     name: Test and build
@@ -103,8 +107,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
 
   deploy_docs:
     name: Deploy docs


### PR DESCRIPTION
This requires to add thrust published on npmjs.com before running `publish_package_to_npm` job. `NPM_PUBLISH_TOKEN` secret can be then removed from repository settings.

---

Closes #685