### PR TITLE
Create a release draft if none is found during release

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -79,7 +79,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release edit "v${{ needs.test_and_build.outputs.version }}" --draft=false
+        run: |
+          if ! gh release view "v${{ needs.test_and_build.outputs.version }}" &>/dev/null;
+          then gh release create "v${{ needs.test_and_build.outputs.version }}" --draft --title "v${{ needs.test_and_build.outputs.version }}";
+          fi gh release edit "v${{ needs.test_and_build.outputs.version }}" --draft=false
 
       - name: Write out the release URL
         run: echo "Released at $RELEASE_URL"


### PR DESCRIPTION
Release draft not found is usually caused by mismatching target branch name: while release-drafter uses `refs/heads/master`, `gh release` needs (or always used to need) `master` which needed to be edited manually on the GitHub Releases page.

This change is a precaution so a release is published regardless the existence of release notes which can be always added later.