### PR TITLE
Fix deployment of docs to `gh-pages` on release, blocked by PR previews

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -164,5 +164,26 @@ jobs:
       - name: Install MkDocs
         run: pip install 'mkdocs-material>=9.0.0,<10.0.0'
 
-      - name: Build and deploy MkDocs
-        run: mkdocs gh-deploy
+      - name: Build docs
+        run: mkdocs build
+
+      # The `gh-pages` branch also holds PR previews under `pr-preview/` (see
+      # pull-request-preview.yml), so `mkdocs gh-deploy` can't be used here: it
+      # replaces the entire branch content, which would wipe those previews.
+      # Deploy manually instead, replacing everything on `gh-pages` except
+      # `pr-preview/` and pushing normally.
+      - name: Deploy docs
+        run: |
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages
+          git worktree add -B gh-pages gh-pages-worktree refs/remotes/origin/gh-pages
+          find gh-pages-worktree -mindepth 1 -maxdepth 1 ! -name pr-preview ! -name .git -exec rm -rf {} +
+          cp -a site/. gh-pages-worktree/
+          touch gh-pages-worktree/.nojekyll
+          cd gh-pages-worktree
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to deploy."
+          else
+            git commit -m "Deploy docs for React UI v${{ needs.test_and_build.outputs.version }} (${GITHUB_SHA:0:7})"
+            git push origin gh-pages
+          fi


### PR DESCRIPTION
## Summary

- `mkdocs gh-deploy` always builds a parentless commit for `gh-pages` (the job's checkout only fetches `master`, so it has no local history for `gh-pages` to branch from), which needs `--force` to push. `--force` was removed when PR previews (`pr-preview/` on `gh-pages`, see `pull-request-preview.yml`) were introduced, to avoid wiping them — but that also means the push is now rejected as a non-fast-forward every time, so no release docs have deployed since v0.63.1.
- Replace `mkdocs gh-deploy` with `mkdocs build` plus a manual deploy step: check out the real `gh-pages` tip into a worktree, replace everything except `pr-preview/` with the freshly built site, add `.nojekyll`, commit, and push normally (a true fast-forward, no force needed).
- Commit message for the deploy now references the React UI release version and source SHA.

## Test plan

- [x] `npm run build` passes
- [x] `mkdocs build` passes
- [x] `npm run lint` passes
- [x] `npm run test:jest` passes
- [x] `npm run test:playwright-ct:all` passes
- [x] Reproduced the original failure and verified the fix against a throwaway git remote mirroring the real `gh-pages` state (preserves `pr-preview/`, deploys new content, no-ops when content is unchanged)
- [x] Confirm `deploy_docs` succeeds on the next real release
