### PR TITLE
Add `remoteUser` to `.devcontainer` to fix JetBrains IDE support (#728)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "../docker-compose.yml"
   ],
   "service": "devcontainer",
+  "remoteUser": "developer",
   "shutdownAction": "stopCompose",
   "workspaceFolder": "/workspace",
   "forwardPorts": [


### PR DESCRIPTION
Opening the project in WebStorm using the Dev Containers "Clone" mode failed during the IDE remote agent bootstrap with:

chgrp: invalid group: '1000:1000'

The `chgrp` call is issued by the JetBrains dev-container helper while it fixes the ownership of its remote agent files. With no user declared in `devcontainer.json`, WebStorm falls back to the Compose `user:` directive (`${COMPOSE_UID}:${COMPOSE_GID}`) and passes the literal `1000:1000` string to `chgrp`, which accepts only a group, never a `uid:gid` pair.

Declaring `"remoteUser": "developer"` makes WebStorm resolve the user via `/etc/passwd` inside the container instead. This is safe on all platforms: `fixuid` rewrites the `developer` entry at container start to match the uid:gid the container runs as, and `devcontainer.json` is not read outside the dev-container workflow (plain `docker compose up`, terminals, CI), so nothing else is affected.