### PR TITLE
Document that `InputGroup` can be used inside `FormLayout` (#713)

### DIFF
--- a/src/components/FormLayout/README.md
+++ b/src/components/FormLayout/README.md
@@ -49,7 +49,8 @@ there are longer validation messages or help texts.
 
 The FormLayout supports buttons and all React UI form fields:
 [Button](/components/Button), [CheckboxField](/components/CheckboxField),
-[FileInputField](/components/FileInputField), [Radio](/components/Radio),
+[FileInputField](/components/FileInputField),
+[InputGroup](/components/InputGroup), [Radio](/components/Radio),
 [SelectField](/components/SelectField), [TextArea](/components/TextArea),
 [TextField](/components/TextField), and [Toggle](/components/Toggle).
 

--- a/src/components/InputGroup/README.md
+++ b/src/components/InputGroup/README.md
@@ -73,6 +73,10 @@ See [API](#api) for all available options.
   [ButtonGroup](/components/ButtonGroup) component which is designed
   specifically for that purpose.
 
+- InputGroup can be used inside [FormLayout](/components/FormLayout). In that
+  case, its `layout` prop is ignored and the value is inherited from
+  FormLayout instead.
+
 ## Sizes
 
 All existing field and button sizes are also available on the input group level:


### PR DESCRIPTION
The `InputGroup` component already inherits its layout from `FormLayout` when nested inside it, but the docs did not mention this. This PR:

* documents in `InputGroup` that it can be used inside `FormLayout`, and that its `layout` prop is ignored in that case,
* adds `InputGroup` to the list of form fields supported by `FormLayout`, since `InputGroup` docs already demonstrate the nesting.

Docs-only change, no functional impact.

Closes #713
