### PR TITLE
Keep theming out of component README prose (#733)

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -26,6 +26,11 @@ See [Commands](../../CLAUDE.md#commands).
   each component's `README.md`; guides and foundations live under `src/docs/`.
 * New pages must be wired into the navigation in [mkdocs.yml](../../mkdocs.yml).
 * Use relative links between docs.
+* Keep theming out of README prose: document it only in the `## Theming` section
+  at the end of a component's `README.md`, including examples that override
+  `--rui-*` custom properties. Other sections must not link to
+  `/docs/customize/theming/*` or to `#theming` — downstream design systems drop
+  the whole section when they sync our docs.
 
 ## Reference
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -25,10 +25,9 @@ See [API](#api) for all available options.
 
 ## General Guidelines
 
-- Default card is **designed for non-white background.** You may want to either
-  use the [raised variant](#raised-card) or
-  [customize](/docs/customize/theming/overview) the default appearance to make the
-  card stand out on white surfaces.
+- Default card is **designed for non-white background.** You may want to use
+  the [raised variant](#raised-card) to make the card stand out on white
+  surfaces.
 
 - Use optional [CardBody](#cardbody) and [CardFooter](#cardfooter) components to
   provide your content with expected spacing.

--- a/src/components/CheckboxField/README.md
+++ b/src/components/CheckboxField/README.md
@@ -205,18 +205,10 @@ React.createElement(() => {
 });
 ```
 
-#### Styling the Required State
+#### Rendering as Required
 
-All form fields in React UI can be
-[styled](/docs/customize/theming/forms/#required-state)
-to indicate the required state.
-
-However, you may find yourself in a situation where a form field is valid in
-both checked and unchecked states, for example to turn on or off a feature.
-If your project uses the label color as the primary means to indicate the
-required state of input fields and the usual asterisk `*` is omitted, you may
-want to keep the label color consistent for both states to avoid confusion.
-
+A form field may be valid in both checked and unchecked states, for example to
+turn on or off a feature, while your design still needs it to look required.
 For this edge case, there is the `renderAsRequired` prop:
 
 ```docoff-react-preview
@@ -224,36 +216,19 @@ React.createElement(() => {
   const [optional, setOptional] = React.useState(false);
   const [renderAsRequired, setRenderAsRequired] = React.useState(false);
   return (
-    <React.Fragment>
-      <style>
-      {`
-        .example {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 1rem 0.5rem;
-        }
-
-        .example--themed-form-fields {
-          --rui-FormField__label__color: var(--rui-color-text-secondary);
-          --rui-FormField--required__label__color: var(--rui-color-text-primary);
-          --rui-FormField--required__sign: '';
-        }
-      `}
-      </style>
-      <div class="example example--themed-form-fields">
-        <CheckboxField
-          checked={optional}
-          label="This field is optional"
-          onChange={() => setOptional(!optional)}
-        />
-        <CheckboxField
-          checked={renderAsRequired}
-          label="This field is optional but looks like required"
-          onChange={() => setRenderAsRequired(!renderAsRequired)}
-          renderAsRequired
-        />
-      </div>
-    </React.Fragment>
+    <>
+      <CheckboxField
+        checked={optional}
+        label="This field is optional"
+        onChange={() => setOptional(!optional)}
+      />
+      <CheckboxField
+        checked={renderAsRequired}
+        label="This field is optional but looks like required"
+        onChange={() => setRenderAsRequired(!renderAsRequired)}
+        renderAsRequired
+      />
+    </>
   );
 });
 ```
@@ -308,6 +283,56 @@ options. On top of that, the following options are available for CheckboxField.
 |----------------------------------------------------------------------|----------------------------------------------|
 | `--rui-FormField--check__input--checkbox__border-radius`             | Input corner radius                          |
 | `--rui-FormField--check__input--checkbox--checked__background-image` | Background image of checked input            |
+
+### Theming the Required State
+
+Required fields are indicated by
+[shared theming options](/docs/customize/theming/forms/#required-state).
+
+If your project uses the label color as the primary means to indicate the
+required state of input fields and the usual asterisk `*` is omitted, you may
+want to keep the label color consistent for fields that are valid in both
+checked and unchecked states. Pair the theming options with the
+[`renderAsRequired`](#rendering-as-required) prop to achieve that:
+
+```docoff-react-preview
+React.createElement(() => {
+  const [optional, setOptional] = React.useState(false);
+  const [renderAsRequired, setRenderAsRequired] = React.useState(false);
+  return (
+    <React.Fragment>
+      <style>
+      {`
+        .example {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem 0.5rem;
+        }
+
+        .example--themed-form-fields {
+          --rui-FormField__label__color: var(--rui-color-text-secondary);
+          --rui-FormField--required__label__color: var(--rui-color-text-primary);
+          --rui-FormField--required__sign: '';
+        }
+      `}
+      </style>
+      <div class="example example--themed-form-fields">
+        <CheckboxField
+          checked={optional}
+          label="This field is optional"
+          onChange={() => setOptional(!optional)}
+        />
+        <CheckboxField
+          checked={renderAsRequired}
+          label="This field is optional but looks like required"
+          onChange={() => setRenderAsRequired(!renderAsRequired)}
+          renderAsRequired
+        />
+      </div>
+    </React.Fragment>
+  );
+});
+```
 
 [checkbox-attributes]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes
 [React common props]: https://react.dev/reference/react-dom/components/common#common-props

--- a/src/components/FormLayout/README.md
+++ b/src/components/FormLayout/README.md
@@ -211,9 +211,6 @@ auto width, and limited width. For cases where an individual manual width works
 better, there is the **local custom width mode** which enables setting a width
 that is applied just for the current FormLayout.
 
-👉 All global label width options can be easily [customized](/docs/customize/theming/overview)
-with CSS custom properties.
-
 #### Label Width Options
 
 - The `default` mode (global) sets the width of all labels to a **global default

--- a/src/components/Paper/README.md
+++ b/src/components/Paper/README.md
@@ -22,9 +22,8 @@ See [API](#api) for all available options.
 
 ## General Guidelines
 
-- Paper is **designed for non-white background.** You may want to either use its
-  [raised variant](#raised-paper) or [customize](/docs/customize/theming/overview)
-  the default appearance to make it stand out on white background.
+- Paper is **designed for non-white background.** You may want to use its
+  [raised variant](#raised-paper) to make it stand out on white background.
 
 - **Paper, or Card?** Paper is a basic surface to put content on. However,
   there is also the [Card](/components/Card) component. While Paper is

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -312,29 +312,6 @@ React.createElement(() => {
 });
 ```
 
-## z-index
-
-By default, the Popover's `z-index` is `auto`, which means it participates in
-the stacking context of its nearest positioned ancestor. This works well in most
-cases, but can cause the Popover to appear behind other positioned elements such
-as sticky headers, fixed toolbars, or modals.
-
-When that happens, set `--rui-Popover__z-index` to a numeric value high enough
-to place the Popover above the conflicting layer. The override can be applied
-globally or scoped to a specific context:
-
-```css
-/* Global override */
-:root {
-  --rui-Popover__z-index: 1000;
-}
-
-/* Scoped override */
-.my-context {
-  --rui-Popover__z-index: 1000;
-}
-```
-
 ## Controlled Popover
 
 Popover API can be used to control visibility of Popover component. You need to
@@ -408,6 +385,29 @@ which enables [Advanced Positioning](#advanced-positioning).
 | `--rui-Popover__background-color`                    | Background color                                             |
 | `--rui-Popover__box-shadow`                          | Popover box shadow                                           |
 | `--rui-Popover__z-index`                             | Popover z-index (default: `auto`)                            |
+
+### z-index
+
+By default, the Popover's `z-index` is `auto`, which means it participates in
+the stacking context of its nearest positioned ancestor. This works well in most
+cases, but can cause the Popover to appear behind other positioned elements such
+as sticky headers, fixed toolbars, or modals.
+
+When that happens, set `--rui-Popover__z-index` to a numeric value high enough
+to place the Popover above the conflicting layer. The override can be applied
+globally or scoped to a specific context:
+
+```css
+/* Global override */
+:root {
+  --rui-Popover__z-index: 1000;
+}
+
+/* Scoped override */
+.my-context {
+  --rui-Popover__z-index: 1000;
+}
+```
 
 [div-attributes]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes
 [Floating UI]: https://floating-ui.com/docs/react-dom

--- a/src/components/Radio/README.md
+++ b/src/components/Radio/README.md
@@ -269,18 +269,10 @@ React.createElement(() => {
 })
 ```
 
-#### Styling the Required State
+#### Rendering as Required
 
-All form fields in React UI can be
-[styled](/docs/customize/theming/forms/#required-state)
-to indicate the required state.
-
-However, you may find yourself in a situation where a form field is valid in
-both selected and unselected states, for example to turn on or off a feature.
-If your project uses the label color as the primary means to indicate the
-required state of input fields and the usual asterisk `*` is omitted, you may
-want to keep the label color consistent for both states to avoid confusion.
-
+A form field may be valid in both selected and unselected states, for example
+to turn on or off a feature, while your design still needs it to look required.
 For this edge case, there is the `renderAsRequired` prop:
 
 ```docoff-react-preview
@@ -301,40 +293,23 @@ React.createElement(() => {
     },
   ];
   return (
-   <React.Fragment>
-      <style>
-      {`
-        .example {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 1rem 0.5rem;
-        }
-
-        .example--themed-form-fields {
-          --rui-FormField__label__color: var(--rui-color-text-secondary);
-          --rui-FormField--required__label__color: var(--rui-color-text-primary);
-          --rui-FormField--required__sign: '';
-        }
-      `}
-      </style>
-      <div class="example example--themed-form-fields">
-        <Radio
-          label="This field is optional"
-          onChange={(e) => setFruit(e.target.value)}
-          options={options}
-          value={fruit}
-        />
-        <Radio
-          label="This field is optional but looks like required"
-          onChange={(e) => setFruit(e.target.value)}
-          options={options}
-          value={fruit}
-          renderAsRequired
-        />
-      </div>
-    </React.Fragment>
+    <>
+      <Radio
+        label="This field is optional"
+        onChange={(e) => setFruit(e.target.value)}
+        options={options}
+        value={fruit}
+      />
+      <Radio
+        label="This field is optional but looks like required"
+        onChange={(e) => setFruit(e.target.value)}
+        options={options}
+        value={fruit}
+        renderAsRequired
+      />
+    </>
   );
-})
+});
 ```
 
 It renders the field as if it was required, but doesn't add the `required`
@@ -409,6 +384,71 @@ options. On top of that, the following options are available for Radio.
 |--------------------------------------------------------------------|--------------------------------------------------|
 | `--rui-FormField--check__input--radio__border-radius`              | Input corner radius                              |
 | `--rui-FormField--check__input--radio--checked__background-image`  | Checked input background image (inline, URL, …)  |
+
+### Theming the Required State
+
+Required fields are indicated by
+[shared theming options](/docs/customize/theming/forms/#required-state).
+
+If your project uses the label color as the primary means to indicate the
+required state of input fields and the usual asterisk `*` is omitted, you may
+want to keep the label color consistent for fields that are valid in both
+selected and unselected states. Pair the theming options with the
+[`renderAsRequired`](#rendering-as-required) prop to achieve that:
+
+```docoff-react-preview
+React.createElement(() => {
+  const [fruit, setFruit] = React.useState('apple');
+  const options = [
+    {
+      label: 'Apple',
+      value: 'apple',
+    },
+    {
+      label: 'Banana',
+      value: 'banana',
+    },
+    {
+      label: 'Grapefruit',
+      value: 'grapefruit',
+    },
+  ];
+  return (
+    <React.Fragment>
+      <style>
+      {`
+        .example {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem 0.5rem;
+        }
+
+        .example--themed-form-fields {
+          --rui-FormField__label__color: var(--rui-color-text-secondary);
+          --rui-FormField--required__label__color: var(--rui-color-text-primary);
+          --rui-FormField--required__sign: '';
+        }
+      `}
+      </style>
+      <div class="example example--themed-form-fields">
+        <Radio
+          label="This field is optional"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+        />
+        <Radio
+          label="This field is optional but looks like required"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+          renderAsRequired
+        />
+      </div>
+    </React.Fragment>
+  );
+});
+```
 
 [accessibility]: https://www.w3.org/WAI/tutorials/forms/grouping/
 [fieldset]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset

--- a/src/components/SelectField/README.md
+++ b/src/components/SelectField/README.md
@@ -78,8 +78,7 @@ mobile devices by using the native select of the platform.
 ## Design Variants
 
 To satisfy the design requirements of your project, all input fields in React UI
-come in two design variants to choose from: outline and filled. Both can be
-further [customized](#theming) with CSS custom properties.
+come in two design variants to choose from: outline and filled.
 
 ```docoff-react-preview
 React.createElement(() => {
@@ -624,18 +623,10 @@ React.createElement(() => {
 });
 ```
 
-#### Styling the Required State
+#### Rendering as Required
 
-All form fields in React UI can be
-[styled](/docs/customize/theming/forms/#required-state)
-to indicate the required state.
-
-However, you may find yourself in a situation where a form field is valid in
-both selected and unselected states, for example to turn on or off a feature.
-If your project uses the label color as the primary means to indicate the
-required state of input fields and the usual asterisk `*` is omitted, you may
-want to keep the label color consistent for both states to avoid confusion.
-
+A form field may be valid in both selected and unselected states, for example
+to turn on or off a feature, while your design still needs it to look required.
 For this edge case, there is the `renderAsRequired` prop:
 
 ```docoff-react-preview
@@ -656,38 +647,21 @@ React.createElement(() => {
     },
   ];
   return (
-   <React.Fragment>
-      <style>
-      {`
-        .example {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 1rem 0.5rem;
-        }
-
-        .example--themed-form-fields {
-          --rui-FormField__label__color: var(--rui-color-text-secondary);
-          --rui-FormField--required__label__color: var(--rui-color-text-primary);
-          --rui-FormField--required__sign: '';
-        }
-      `}
-      </style>
-      <div class="example example--themed-form-fields">
+    <>
       <SelectField
-          label="This field is optional"
-          onChange={(e) => setFruit(e.target.value)}
-          options={options}
-          value={fruit}
-        />
-        <SelectField
-          label="This field is optional but looks like required"
-          onChange={(e) => setFruit(e.target.value)}
-          options={options}
-          value={fruit}
-          renderAsRequired
-        />
-      </div>
-    </React.Fragment>
+        label="This field is optional"
+        onChange={(e) => setFruit(e.target.value)}
+        options={options}
+        value={fruit}
+      />
+      <SelectField
+        label="This field is optional but looks like required"
+        onChange={(e) => setFruit(e.target.value)}
+        options={options}
+        value={fruit}
+        renderAsRequired
+      />
+    </>
   );
 });
 ```
@@ -784,6 +758,71 @@ options. On top of that, the following options are available for SelectField.
 | `--rui-FormField--box--select__caret__border-style`     | SelectField arrow border style (e.g. `solid`)                |
 | `--rui-FormField--box--select__caret__background`       | SelectField arrow background (including `url()` or gradient) |
 | `--rui-FormField--box--select__option--disabled__color` | Text color of disabled SelectField options                   |
+
+### Theming the Required State
+
+Required fields are indicated by
+[shared theming options](/docs/customize/theming/forms/#required-state).
+
+If your project uses the label color as the primary means to indicate the
+required state of input fields and the usual asterisk `*` is omitted, you may
+want to keep the label color consistent for fields that are valid in both
+selected and unselected states. Pair the theming options with the
+[`renderAsRequired`](#rendering-as-required) prop to achieve that:
+
+```docoff-react-preview
+React.createElement(() => {
+  const [fruit, setFruit] = React.useState('apple');
+  const options = [
+    {
+      label: 'Apple',
+      value: 'apple',
+    },
+    {
+      label: 'Banana',
+      value: 'banana',
+    },
+    {
+      label: 'Grapefruit',
+      value: 'grapefruit',
+    },
+  ];
+  return (
+    <React.Fragment>
+      <style>
+      {`
+        .example {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem 0.5rem;
+        }
+
+        .example--themed-form-fields {
+          --rui-FormField__label__color: var(--rui-color-text-secondary);
+          --rui-FormField--required__label__color: var(--rui-color-text-primary);
+          --rui-FormField--required__sign: '';
+        }
+      `}
+      </style>
+      <div class="example example--themed-form-fields">
+        <SelectField
+          label="This field is optional"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+        />
+        <SelectField
+          label="This field is optional but looks like required"
+          onChange={(e) => setFruit(e.target.value)}
+          options={options}
+          value={fruit}
+          renderAsRequired
+        />
+      </div>
+    </React.Fragment>
+  );
+});
+```
 
 [React common props]: https://react.dev/reference/react-dom/components/common#common-props
 [ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/components/TextArea/README.md
+++ b/src/components/TextArea/README.md
@@ -47,8 +47,7 @@ See [API](#api) for all available options.
 ## Design Variants
 
 To satisfy the design requirements of your project, all input fields in React UI
-come in **two design variants** to choose from: outline and filled. Both can be
-further [customized](#theming) with CSS custom properties.
+come in **two design variants** to choose from: outline and filled.
 
 ```docoff-react-preview
 <TextArea
@@ -109,11 +108,9 @@ Full-width fields span the full width of a parent:
 
 ## Input Size
 
-The default width of all inputs is 240 px, and it can be
-[customized](/docs/customize/theming/overview) with a CSS custom property.
-However, you can also **control the size of individual text areas** using
-the `rows` and `cols` properties. Additionally, text areas are vertically
-resizable by users.
+The default width of all inputs is 240 px. You can **control the size of
+individual text areas** using the `rows` and `cols` properties. Additionally,
+text areas are vertically resizable by users.
 
 👉 Remember that the `cols` and `rows` HTML attributes **do not limit on how
 many characters** the user can enter. Use the

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -60,8 +60,7 @@ See [API](#api) for all available options.
 ## Design Variants
 
 To satisfy the design requirements of your project, all input fields in React UI
-come in **two design variants** to choose from: outline and filled. Both can be
-further [customized](#theming) with CSS custom properties.
+come in **two design variants** to choose from: outline and filled.
 
 ```docoff-react-preview
 <TextField
@@ -166,8 +165,7 @@ and `tel` types at your disposal.
 
 ## Input Size
 
-The default width of all inputs is 240 px, and it can be [customized](#theming)
-with a CSS custom property. However, you can also **change the width of
+The default width of all inputs is 240 px. You can **change the width of
 individual text fields** using the `inputSize` property. It (obviously) sets the
 `size` attribute of the `input` element and is further picked up by CSS to
 normalize rendering across browsers.
@@ -516,7 +514,8 @@ If you provide [ref], it is forwarded to the native HTML `<input>` element.
 
 ## Theming
 
-Head to [Forms Theming][theming-forms] to see shared form theming options.
+Head to [Forms Theming](/docs/customize/theming/forms) to see shared form
+theming options.
 
 [pattern]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern
 [autocomplete]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
@@ -528,6 +527,5 @@ Head to [Forms Theming][theming-forms] to see shared form theming options.
 [input-number]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#additional_attributes
 [input-tel]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel#additional_attributes
 [input-password]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#additional_attributes
-[theming-forms]: /docs/customize/theming/forms
 [React common props]: https://react.dev/reference/react-dom/components/common#common-props
 [ref]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/src/components/Toggle/README.md
+++ b/src/components/Toggle/README.md
@@ -181,18 +181,10 @@ React.createElement(() => {
 });
 ```
 
-#### Styling the Required State
+#### Rendering as Required
 
-All form fields in React UI can be
-[styled](/docs/customize/theming/forms/#required-state)
-to indicate the required state.
-
-However, you may find yourself in a situation where a form field is valid in
-both checked and unchecked states, for example to turn on or off a feature.
-If your project uses the label color as the primary means to indicate the
-required state of input fields and the usual asterisk `*` is omitted, you may
-want to keep the label color consistent for both states to avoid confusion.
-
+A form field may be valid in both checked and unchecked states, for example to
+turn on or off a feature, while your design still needs it to look required.
 For this edge case, there is the `renderAsRequired` prop:
 
 ```docoff-react-preview
@@ -200,36 +192,19 @@ React.createElement(() => {
   const [optional, setOptional] = React.useState(false);
   const [renderAsRequired, setRenderAsRequired] = React.useState(false);
   return (
-    <React.Fragment>
-      <style>
-      {`
-        .example {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 1rem 0.5rem;
-        }
-
-        .example--themed-form-fields {
-          --rui-FormField__label__color: var(--rui-color-text-secondary);
-          --rui-FormField--required__label__color: var(--rui-color-text-primary);
-          --rui-FormField--required__sign: '';
-        }
-      `}
-      </style>
-      <div class="example example--themed-form-fields">
-       <Toggle
-          checked={optional}
-          label="This field is optional"
-          onChange={() => setOptional(!optional)}
-        />
-        <Toggle
-          checked={renderAsRequired}
-          label="This field is optional but looks like required"
-          onChange={() => setRenderAsRequired(!renderAsRequired)}
-          renderAsRequired
-        />
-      </div>
-    </React.Fragment>
+    <>
+      <Toggle
+        checked={optional}
+        label="This field is optional"
+        onChange={() => setOptional(!optional)}
+      />
+      <Toggle
+        checked={renderAsRequired}
+        label="This field is optional but looks like required"
+        onChange={() => setRenderAsRequired(!renderAsRequired)}
+        renderAsRequired
+      />
+    </>
   );
 });
 ```
@@ -286,6 +261,56 @@ options. On top of that, the following options are available for Toggle.
 | `--rui-FormField--check__input--toggle--default__background-position` | Background position of unchecked input                 |
 | `--rui-FormField--check__input--toggle--checked__background-image`    | Background image of checked input                      |
 | `--rui-FormField--check__input--toggle--checked__background-position` | Background position of checked input                   |
+
+### Theming the Required State
+
+Required fields are indicated by
+[shared theming options](/docs/customize/theming/forms/#required-state).
+
+If your project uses the label color as the primary means to indicate the
+required state of input fields and the usual asterisk `*` is omitted, you may
+want to keep the label color consistent for fields that are valid in both
+checked and unchecked states. Pair the theming options with the
+[`renderAsRequired`](#rendering-as-required) prop to achieve that:
+
+```docoff-react-preview
+React.createElement(() => {
+  const [optional, setOptional] = React.useState(false);
+  const [renderAsRequired, setRenderAsRequired] = React.useState(false);
+  return (
+    <React.Fragment>
+      <style>
+      {`
+        .example {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem 0.5rem;
+        }
+
+        .example--themed-form-fields {
+          --rui-FormField__label__color: var(--rui-color-text-secondary);
+          --rui-FormField--required__label__color: var(--rui-color-text-primary);
+          --rui-FormField--required__sign: '';
+        }
+      `}
+      </style>
+      <div class="example example--themed-form-fields">
+        <Toggle
+          checked={optional}
+          label="This field is optional"
+          onChange={() => setOptional(!optional)}
+        />
+        <Toggle
+          checked={renderAsRequired}
+          label="This field is optional but looks like required"
+          onChange={() => setRenderAsRequired(!renderAsRequired)}
+          renderAsRequired
+        />
+      </div>
+    </React.Fragment>
+  );
+});
+```
 
 [checkbox-attributes]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes
 [React common props]: https://react.dev/reference/react-dom/components/common#common-props

--- a/src/docs/contribute/general-guidelines.md
+++ b/src/docs/contribute/general-guidelines.md
@@ -339,6 +339,12 @@ the documentation platform.
 
 Do see their respective documentation for details.
 
+**Keep theming out of README prose.** Theming belongs to the `## Theming`
+section at the end of a component's `README.md`, including examples that
+override `--rui-*` custom properties. Other sections must not link to the
+theming guides or to `#theming` so that the whole section can be dropped when
+the docs are reused in a design system that doesn't expose theming.
+
 [Development Containers]: https://containers.dev/
 [Docker]: https://docs.docker.com/get-started/
 [Docker Compose]: https://docs.docker.com/compose/

--- a/src/docs/customize/theming/forms.md
+++ b/src/docs/customize/theming/forms.md
@@ -611,10 +611,10 @@ the `renderAsRequired` prop to `true`. This is useful when
 `--rui-FormField--required__label__color` is used to indicate the required state
 of input fields, but you want to bypass it for inputs like feature toggles.
 This applies to
-[CheckboxField](/components/CheckboxField/#styling-the-required-state),
-[Radio](/components/Radio/#styling-the-required-state),
-[SelectField](/components/SelectField/#styling-the-required-state),
-and [Toggle](/components/Toggle/#styling-the-required-state).
+[CheckboxField](/components/CheckboxField/#theming-the-required-state),
+[Radio](/components/Radio/#theming-the-required-state),
+[SelectField](/components/SelectField/#theming-the-required-state),
+and [Toggle](/components/Toggle/#theming-the-required-state).
 
 ## Disabled State
 


### PR DESCRIPTION
Component READMEs are reused in downstream design systems where theming is an implementation detail, so the whole `## Theming` section is dropped when syncing. Today that cut is not safe: theming leaks into prose elsewhere in the file, which turns every upstream edit into a manual sync conflict.

This moves every theming reference into the `## Theming` section, so removing that section leaves a coherent document.

## Changes

* Dropped theming links and the clauses that only describe theming from `Card`, `Paper`, `FormLayout`, `TextField`, `TextArea`, and `SelectField`.
* Split `Styling the Required State` in `CheckboxField`, `Radio`, `SelectField`, and `Toggle` into two parts:
    * `Rendering as Required` under _States_ keeps the `renderAsRequired` prop story, with a plain example.
    * `Theming the Required State` under _Theming_ carries the Forms Theming link, the label color edge case, and the example that overrides `--rui-*` custom properties.
* Moved the `Popover` `z-index` section under _Theming_ — it documented nothing but the `--rui-Popover__z-index` override, which is already listed in the theming table.
* Inlined the `[theming-forms]` link in `TextField` so its definition doesn't outlive the section that uses it.
* Repointed the four component links in _Forms Theming_ to the new anchors.
* Recorded the rule in the [contributing guide](src/docs/contribute/general-guidelines.md#documenting) and in [Claude rules](.claude/rules/docs.md).

## Verification

* `npm run lint` and `mkdocs build` pass.
* No `theming` mention or `--rui-*` custom property is left above a `## Theming` heading, apart from `ScrollView`, whose `--rui-local-*` properties are arguments for the `startShadowBackground` and `endShadowBackground` options, not theming options.
* Simulated the downstream cut on all 20 READMEs with a `## Theming` section: no leftovers and no orphaned link reference definitions.

Closes #733
